### PR TITLE
CI tests: Use mock crust as feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ safe_core = "~0.12.1"
 
 [features]
 use-mock-routing = []
+use-mock-crust = []
 
 [[test]]
 harness = false


### PR DESCRIPTION
Enable running tests with use-mock-crust feature on.

+@dirvine +@Fraser999