### PR TITLE
MaidManager update for ImmutableData changes.

### DIFF
--- a/src/vault.rs
+++ b/src/vault.rs
@@ -129,6 +129,7 @@ impl Vault {
                 warn!("Failed to handle event: {:?}", error);
             }
 
+            self.maid_manager.check_timeout(routing_node);
             self.pmid_manager.check_timeout(routing_node);
         }
 


### PR DESCRIPTION
1. Accept Put for ImmutableData iff the data is Normal.
2. Updated TimedBuffer, in particular to suit current use case returns keys for expired entries.
2. Use TimedBuffer for MaidManager request_cache.
4. Adds check_timeout fn to MaidManager and calls from vault main loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/388) &emsp; Multiple assignees:&emsp;<img alt="@Fraser999" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/190532?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/Fraser999">Fraser999</a>,&emsp;<img alt="@dirvine" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/123627?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/dirvine">dirvine</a>,&emsp;<img alt="@maqi" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/568777?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/maqi">maqi</a>
<!-- Reviewable:end -->
