### PR TITLE
Allow network to report `NetworkFull` to Clients.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,23 @@ version = "0.5.0"
 
 [dependencies]
 chunk_store = "~0.3.0"
-clippy = {version = "~0.0.59", optional = true}
+clippy = {version = "~0.0.61", optional = true}
 config_file_handler = "~0.3.0"
 ctrlc = "~1.1.1"
 docopt = "~0.6.78"
 log = "~0.3.5"
-maidsafe_utilities = "~0.5.0"
+maidsafe_utilities = "~0.5.1"
 routing = "~0.12.0"
-rustc-serialize = "~0.3.18"
-safe_network_common = "~0.0.1"
-sodiumoxide = "~0.0.9"
-time = "~0.1.34"
+rustc-serialize = "~0.3.19"
+safe_network_common = "~0.1.1"
+sodiumoxide = "~0.0.10"
+time = "~0.1.35"
 xor_name = "~0.1.0"
 
 [dev-dependencies]
 kademlia_routing_table = "~0.4.0"
 rand = "~0.3.14"
-safe_core = "~0.13.0"
+safe_core = "~0.13.1"
 
 [features]
 use-mock-routing = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ pub fn main() {
     let underline = unwrap_result!(String::from_utf8(vec!['=' as u8; message.len()]));
     info!("\n\n{}\n{}", message, underline);
 
-    let mut vault = unwrap_result!(Vault::new(None));
+    let mut vault = unwrap_result!(Vault::new());
     unwrap_result!(vault.run());
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,5 +133,5 @@ pub fn main() {
 #[cfg(feature = "use-mock-crust")]
 #[allow(missing_docs)]
 pub fn main() {
-  println!("Error: mock crust not supported");
+    println!("Error: mock crust not supported");
 }

--- a/src/personas/pmid_node.rs
+++ b/src/personas/pmid_node.rs
@@ -103,7 +103,11 @@ impl PmidNode {
                data_name,
                dst);
         let external_error_indicator = try!(serialisation::serialise(&Vec::<u8>::new()));
-        let _ = routing_node.send_put_failure(src, dst, request.clone(), external_error_indicator, *message_id);
+        let _ = routing_node.send_put_failure(src,
+                                              dst,
+                                              request.clone(),
+                                              external_error_indicator,
+                                              *message_id);
         Ok(())
     }
 
@@ -168,8 +172,8 @@ mod test {
     use safe_network_common::client_errors::GetError;
     use maidsafe_utilities::serialisation;
     use rand::random;
-    use routing::{Authority, Data, DataRequest, ImmutableData, ImmutableDataType, MessageId, RequestContent,
-                  RequestMessage, ResponseContent};
+    use routing::{Authority, Data, DataRequest, ImmutableData, ImmutableDataType, MessageId,
+                  RequestContent, RequestMessage, ResponseContent};
     use sodiumoxide::crypto::hash::sha512;
     use std::sync::mpsc;
     use utils::generate_random_vec_u8;
@@ -191,8 +195,7 @@ mod test {
         loop {
             if let Ok(Some(_)) = routing.close_group(name) {
                 break;
-            }
-            else {
+            } else {
                 name = random::<XorName>();
             }
         }
@@ -283,7 +286,7 @@ mod test {
         assert_eq!(put_failures[0].src, env.our_authority);
         assert_eq!(put_failures[0].dst, env.from_authority);
 
-        if let ResponseContent::PutFailure{ ref id, ref request, ref external_error_indicator } =
+        if let ResponseContent::PutFailure { ref id, ref request, ref external_error_indicator } =
                put_failures[0].content {
             assert_eq!(*id, message_id);
             assert_eq!(*request, request_msg);
@@ -336,7 +339,9 @@ mod test {
         }
 
         let message_id = MessageId::new();
-        let name = if let Authority::ManagedNode(name) = env.our_authority { name } else {
+        let name = if let Authority::ManagedNode(name) = env.our_authority {
+            name
+        } else {
             unreachable!()
         };
         let request_msg = RequestMessage {
@@ -359,7 +364,7 @@ mod test {
         assert_eq!(get_successes[0].src, env.our_authority);
         assert_eq!(get_successes[0].dst, Authority::NaeManager(name));
 
-        if let ResponseContent::GetSuccess(ref data, ref id) = get_successes[0].content  {
+        if let ResponseContent::GetSuccess(ref data, ref id) = get_successes[0].content {
             assert_eq!(*data, Data::Immutable(immutable_data));
             assert_eq!(*id, message_id);
         } else {
@@ -378,7 +383,9 @@ mod test {
         let mut env = environment_setup(capacity);
 
         let message_id = MessageId::new();
-        let name = if let Authority::ManagedNode(name) = env.our_authority { name } else {
+        let name = if let Authority::ManagedNode(name) = env.our_authority {
+            name
+        } else {
             unreachable!()
         };
         let request_msg = RequestMessage {
@@ -401,12 +408,14 @@ mod test {
         assert_eq!(get_failures[0].src, env.our_authority);
         assert_eq!(get_failures[0].dst, Authority::NaeManager(name));
 
-        if let ResponseContent::GetFailure{ ref id, ref request, ref external_error_indicator } =
+        if let ResponseContent::GetFailure { ref id, ref request, ref external_error_indicator } =
                get_failures[0].content {
             assert_eq!(*id, message_id);
             assert_eq!(*request, request_msg);
             let error = unwrap_result!(serialisation::deserialise(external_error_indicator));
-            if let GetError::NoSuchData = error {} else { unreachable!() }
+            if let GetError::NoSuchData = error {} else {
+                unreachable!()
+            }
         } else {
             unreachable!()
         }
@@ -455,7 +464,9 @@ mod test {
         env.pmid_node.handle_churn(&env.routing);
 
         let message_id = MessageId::new();
-        let name = if let Authority::ManagedNode(name) = env.our_authority { name } else {
+        let name = if let Authority::ManagedNode(name) = env.our_authority {
+            name
+        } else {
             unreachable!()
         };
         let request_msg = RequestMessage {
@@ -479,7 +490,7 @@ mod test {
             assert_eq!(get_successes[0].src, env.our_authority);
             assert_eq!(get_successes[0].dst, Authority::NaeManager(name));
 
-            if let ResponseContent::GetSuccess(ref data, ref id) = get_successes[0].content  {
+            if let ResponseContent::GetSuccess(ref data, ref id) = get_successes[0].content {
                 assert_eq!(*data, Data::Immutable(immutable_data));
                 assert_eq!(*id, message_id);
             } else {
@@ -496,12 +507,16 @@ mod test {
             assert_eq!(get_failures[0].src, env.our_authority);
             assert_eq!(get_failures[0].dst, Authority::NaeManager(name));
 
-            if let ResponseContent::GetFailure{ ref id, ref request, ref external_error_indicator } =
-                   get_failures[0].content {
+            if let ResponseContent::GetFailure { ref id,
+                                                 ref request,
+                                                 ref external_error_indicator } = get_failures[0]
+                                                                                      .content {
                 assert_eq!(*id, message_id);
                 assert_eq!(*request, request_msg);
                 let error = unwrap_result!(serialisation::deserialise(external_error_indicator));
-                if let GetError::NoSuchData = error {} else { unreachable!() }
+                if let GetError::NoSuchData = error {} else {
+                    unreachable!()
+                }
             } else {
                 unreachable!()
             }

--- a/src/personas/structured_data_manager.rs
+++ b/src/personas/structured_data_manager.rs
@@ -275,8 +275,8 @@ mod test {
     use maidsafe_utilities::serialisation;
     use rand::distributions::{IndependentSample, Range};
     use rand::{random, thread_rng};
-    use routing::{Authority, Data, DataRequest, MessageId, RequestContent,
-                  RequestMessage, ResponseContent, ResponseMessage, StructuredData};
+    use routing::{Authority, Data, DataRequest, MessageId, RequestContent, RequestMessage,
+                  ResponseContent, ResponseMessage, StructuredData};
     use safe_network_common::client_errors::{GetError, MutationError};
     use sodiumoxide::crypto::hash::sha512;
     use sodiumoxide::crypto::sign::{self, PublicKey, SecretKey};
@@ -335,8 +335,7 @@ mod test {
         pub fn get_close_data(&self, keys: (PublicKey, SecretKey)) -> StructuredData {
             loop {
                 let identifier = random();
-                let structured_data =
-                    unwrap_result!(StructuredData::new(0,
+                let structured_data = unwrap_result!(StructuredData::new(0,
                                                        identifier,
                                                        0,
                                                        utils::generate_random_vec_u8(1024),
@@ -520,7 +519,8 @@ mod test {
             panic!("Received unexpected response {:?}", put_responses[0]);
         }
         assert_eq!(put_env.client_manager, put_responses[0].dst);
-        assert_eq!(Authority::NaeManager(put_env.sd_data.name()), put_responses[0].src);
+        assert_eq!(Authority::NaeManager(put_env.sd_data.name()),
+                   put_responses[0].src);
 
         let get_env = env.get_sd_data(put_env.sd_data.clone());
         let get_responses = env.routing.get_successes_given();
@@ -535,7 +535,7 @@ mod test {
         assert_eq!(get_responses[0].dst, get_env.client);
     }
 
-   #[test]
+    #[test]
     fn handle_put_get_error_flow() {
         // This shows a non-owner can still store the sd_data
         let mut env = Environment::new();
@@ -552,7 +552,7 @@ mod test {
         assert_eq!(put_failures.len(), 1);
         assert_eq!(put_failures[0].dst, put_existing_env.client_manager);
 
-        if let ResponseContent::PutFailure{ ref id, ref request, ref external_error_indicator } =
+        if let ResponseContent::PutFailure { ref id, ref request, ref external_error_indicator } =
                put_failures[0].content {
             assert_eq!(*id, put_existing_env.message_id);
             assert_eq!(*request, put_existing_env.request);
@@ -573,7 +573,7 @@ mod test {
         assert_eq!(env.routing.get_successes_given().len(), 0);
         let get_failure = env.routing.get_failures_given();
         assert_eq!(get_failure.len(), 1);
-        if let ResponseContent::GetFailure{ ref external_error_indicator, ref id, .. } =
+        if let ResponseContent::GetFailure { ref external_error_indicator, ref id, .. } =
                get_failure[0].content.clone() {
             assert_eq!(get_env.message_id, *id);
             let parsed_error = unwrap_result!(serialisation::deserialise(external_error_indicator));
@@ -585,7 +585,8 @@ mod test {
             panic!("Received unexpected response {:?}", get_failure[0]);
         }
         assert_eq!(get_env.client, get_failure[0].dst);
-        assert_eq!(Authority::NaeManager(non_existing_sd_data.name()), get_failure[0].src);
+        assert_eq!(Authority::NaeManager(non_existing_sd_data.name()),
+                   get_failure[0].src);
     }
 
     #[test]
@@ -596,7 +597,7 @@ mod test {
         assert_eq!(None, env.get_from_chunkstore(&post_env.sd_data.name()));
         let mut post_failure = env.routing.post_failures_given();
         assert_eq!(post_failure.len(), 1);
-        if let ResponseContent::PostFailure{ ref external_error_indicator, ref id, .. } =
+        if let ResponseContent::PostFailure { ref external_error_indicator, ref id, .. } =
                post_failure[0].content.clone() {
             assert_eq!(post_env.message_id, *id);
             assert!(external_error_indicator.is_empty());
@@ -604,7 +605,8 @@ mod test {
             panic!("Received unexpected response {:?}", post_failure[0]);
         }
         assert_eq!(post_env.client, post_failure[0].dst);
-        assert_eq!(Authority::NaeManager(post_env.sd_data.name()), post_failure[0].src);
+        assert_eq!(Authority::NaeManager(post_env.sd_data.name()),
+                   post_failure[0].src);
 
         // PUT the data
         let put_env = env.put_existing_sd_data(post_env.sd_data.clone(), post_env.keys.clone());
@@ -614,7 +616,9 @@ mod test {
         let mut sd_new_bad = unwrap_result!(StructuredData::new(0,
                                                                 *put_env.sd_data.get_identifier(),
                                                                 3,
-                                                                put_env.sd_data.get_data().clone(),
+                                                                put_env.sd_data
+                                                                       .get_data()
+                                                                       .clone(),
                                                                 vec![put_env.keys.0],
                                                                 vec![],
                                                                 Some(&put_env.keys.1)));
@@ -623,7 +627,7 @@ mod test {
                                                            put_env.client.clone());
         post_failure = env.routing.post_failures_given();
         assert_eq!(post_failure.len(), 2);
-        if let ResponseContent::PostFailure{ ref external_error_indicator, ref id, .. } =
+        if let ResponseContent::PostFailure { ref external_error_indicator, ref id, .. } =
                post_failure[1].content.clone() {
             assert_eq!(post_incorrect_env.message_id, *id);
             assert!(external_error_indicator.is_empty());
@@ -631,7 +635,8 @@ mod test {
             panic!("Received unexpected response {:?}", post_failure[1]);
         }
         assert_eq!(post_incorrect_env.client, post_failure[1].dst);
-        assert_eq!(Authority::NaeManager(post_incorrect_env.sd_data.name()), post_failure[1].src);
+        assert_eq!(Authority::NaeManager(post_incorrect_env.sd_data.name()),
+                   post_failure[1].src);
         assert_eq!(Some(put_env.sd_data.clone()),
                    env.get_from_chunkstore(&sd_new_bad.name()));
 
@@ -657,7 +662,8 @@ mod test {
             panic!("Received unexpected response {:?}", post_success[0]);
         }
         assert_eq!(post_correct_env.client, post_success[0].dst);
-        assert_eq!(Authority::NaeManager(post_correct_env.sd_data.name()), post_success[0].src);
+        assert_eq!(Authority::NaeManager(post_correct_env.sd_data.name()),
+                   post_success[0].src);
         assert_eq!(Some(sd_new.clone()),
                    env.get_from_chunkstore(&put_env.sd_data.name()));
 
@@ -675,8 +681,9 @@ mod test {
                                           put_env.client.clone());
         post_failure = env.routing.post_failures_given();
         assert_eq!(post_failure.len(), 3);
-        if let ResponseContent::PostFailure{ ref external_error_indicator, .. } =
-               post_failure[2].content.clone() {
+        if let ResponseContent::PostFailure { ref external_error_indicator, .. } = post_failure[2]
+                                                                                       .content
+                                                                                       .clone() {
             assert!(external_error_indicator.is_empty());
         } else {
             panic!("Received unexpected response {:?}", post_failure[2]);
@@ -717,7 +724,7 @@ mod test {
         assert_eq!(None, env.get_from_chunkstore(&delete_env.sd_data.name()));
         let mut delete_failure = env.routing.delete_failures_given();
         assert_eq!(delete_failure.len(), 1);
-        if let ResponseContent::DeleteFailure{ ref external_error_indicator, ref id, .. } =
+        if let ResponseContent::DeleteFailure { ref external_error_indicator, ref id, .. } =
                delete_failure[0].content.clone() {
             assert_eq!(delete_env.message_id, *id);
             assert!(external_error_indicator.is_empty());
@@ -725,7 +732,8 @@ mod test {
             panic!("Received unexpected response {:?}", delete_failure[0]);
         }
         assert_eq!(delete_env.client, delete_failure[0].dst);
-        assert_eq!(Authority::NaeManager(delete_env.sd_data.name()), delete_failure[0].src);
+        assert_eq!(Authority::NaeManager(delete_env.sd_data.name()),
+                   delete_failure[0].src);
 
         // PUT the data
         let put_env = env.put_existing_sd_data(delete_env.sd_data.clone(), delete_env.keys.clone());
@@ -744,7 +752,7 @@ mod test {
                                             put_env.client.clone());
         delete_failure = env.routing.delete_failures_given();
         assert_eq!(delete_failure.len(), 2);
-        if let ResponseContent::DeleteFailure{ ref external_error_indicator, .. } =
+        if let ResponseContent::DeleteFailure { ref external_error_indicator, .. } =
                delete_failure[1].content.clone() {
             assert!(external_error_indicator.is_empty());
         } else {
@@ -775,7 +783,8 @@ mod test {
             panic!("Received unexpected response {:?}", delete_success[0]);
         }
         assert_eq!(delete_correct_env.client, delete_success[0].dst);
-        assert_eq!(Authority::NaeManager(delete_correct_env.sd_data.name()), delete_success[0].src);
+        assert_eq!(Authority::NaeManager(delete_correct_env.sd_data.name()),
+                   delete_success[0].src);
         assert_eq!(None, env.get_from_chunkstore(&put_env.sd_data.name()));
 
         // block put after deletion
@@ -807,14 +816,17 @@ mod test {
 
         let refresh_requests = env.routing.refresh_requests_given();
         assert_eq!(refresh_requests.len(), 1);
-        assert_eq!(refresh_requests[0].src, Authority::NaeManager(put_env.sd_data.name()));
-        assert_eq!(refresh_requests[0].dst, Authority::NaeManager(put_env.sd_data.name()));
-        if let RequestContent::Refresh(received_serialised_refresh) = refresh_requests[0].content
-                                                                                         .clone() {
+        assert_eq!(refresh_requests[0].src,
+                   Authority::NaeManager(put_env.sd_data.name()));
+        assert_eq!(refresh_requests[0].dst,
+                   Authority::NaeManager(put_env.sd_data.name()));
+        if let RequestContent::Refresh(received_serialised_refresh) = refresh_requests[0]
+                                                                          .content
+                                                                          .clone() {
             let parsed_refresh = unwrap_result!(serialisation::deserialise::<Refresh>(
                     &received_serialised_refresh[..]));
-            if let RefreshValue::StructuredDataManager(received_data) =
-                   parsed_refresh.value.clone() {
+            if let RefreshValue::StructuredDataManager(received_data) = parsed_refresh.value
+                                                                                      .clone() {
                 assert_eq!(received_data, put_env.sd_data);
             } else {
                 panic!("Received unexpected refresh value {:?}", parsed_refresh);
@@ -861,4 +873,3 @@ mod test {
                    env.get_from_chunkstore(&sd_data.name()));
     }
 }
-

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,11 +42,12 @@ fn plain_data_put_and_get() {
 
     client.put(Data::Immutable(orig_data.clone()), &mut nodes);
 
-    match client.get(DataRequest::Immutable(orig_data.name(), ImmutableDataType::Normal), &mut nodes) {
+    match client.get(DataRequest::Immutable(orig_data.name(), ImmutableDataType::Normal),
+                     &mut nodes) {
         Data::Immutable(data) => {
             assert_eq!(data.name(), orig_data.name());
             assert!(data.value() == orig_data.value());
-        },
+        }
 
         data => panic!("Got unexpected data: {:?}", data),
     }

--- a/src/tests/test_client.rs
+++ b/src/tests/test_client.rs
@@ -16,8 +16,8 @@
 // relating to use of the SAFE Network Software.
 
 use rand::random;
-use routing::{self, Authority, Data, DataRequest, Event, FullId, MessageId, PublicId, ResponseContent,
-              ResponseMessage, StructuredData};
+use routing::{self, Authority, Data, DataRequest, Event, FullId, MessageId, PublicId,
+              ResponseContent, ResponseMessage, StructuredData};
 use routing::mock_crust::{self, Config, Network, ServiceHandle};
 use std::sync::mpsc::{self, Receiver};
 
@@ -32,7 +32,7 @@ pub struct TestClient {
 }
 
 impl TestClient {
-    pub fn new(network: &Network,  config: Option<Config>) -> Self {
+    pub fn new(network: &Network, config: Option<Config>) -> Self {
         let (routing_tx, routing_rx) = mpsc::channel();
 
         let full_id = FullId::new();

--- a/src/tests/test_node.rs
+++ b/src/tests/test_node.rs
@@ -28,9 +28,7 @@ pub struct TestNode {
 impl TestNode {
     pub fn new(network: &Network, config: Option<Config>) -> Self {
         let handle = network.new_service_handle(config, None);
-        let vault = mock_crust::make_current(&handle, || {
-            unwrap_result!(Vault::new(None))
-        });
+        let vault = mock_crust::make_current(&handle, || unwrap_result!(Vault::new(None)));
 
         TestNode {
             handle: handle,
@@ -53,7 +51,7 @@ impl TestNode {
     }
 }
 
-pub fn create_nodes(network:& Network, size: usize) -> Vec<TestNode> {
+pub fn create_nodes(network: &Network, size: usize) -> Vec<TestNode> {
     let mut nodes = Vec::new();
 
     // Create the seed node.

--- a/src/tests/test_node.rs
+++ b/src/tests/test_node.rs
@@ -28,7 +28,7 @@ pub struct TestNode {
 impl TestNode {
     pub fn new(network: &Network, config: Option<Config>) -> Self {
         let handle = network.new_service_handle(config, None);
-        let vault = mock_crust::make_current(&handle, || unwrap_result!(Vault::new(None)));
+        let vault = mock_crust::make_current(&handle, || unwrap_result!(Vault::new()));
 
         TestNode {
             handle: handle,

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -59,16 +59,21 @@ pub struct Vault {
     structured_data_manager: StructuredDataManager,
     app_event_sender: Option<Sender<Event>>,
 
-    #[cfg(feature = "use-mock-crust")] routing_node: Option<RoutingNode>,
-    #[cfg(feature = "use-mock-crust")] routing_receiver: Receiver<Event>,
+    #[cfg(feature = "use-mock-crust")]
+    routing_node: Option<RoutingNode>,
+    #[cfg(feature = "use-mock-crust")]
+    routing_receiver: Receiver<Event>,
 }
 
-fn init_components() -> Result<(ImmutableDataManager,
-                                MaidManager,
-                                MpidManager,
-                                PmidManager,
-                                PmidNode,
-                                StructuredDataManager), InternalError> {
+fn init_components()
+    -> Result<(ImmutableDataManager,
+               MaidManager,
+               MpidManager,
+               PmidManager,
+               PmidNode,
+               StructuredDataManager),
+              InternalError>
+{
     ::sodiumoxide::init();
 
     let config = try!(config_handler::read_config_file());

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -37,7 +37,8 @@
 #![cfg_attr(feature="clippy", allow(use_debug))]
 
 // To avoid multiple cfg statements before each import.
-#![cfg_attr(any(feature="use-mock-routing", feature="use-mock-crust"), allow(unused, unused_extern_crates))]
+#![cfg_attr(any(feature="use-mock-routing", feature="use-mock-crust"),
+   allow(unused, unused_extern_crates))]
 
 extern crate kademlia_routing_table;
 #[macro_use]


### PR DESCRIPTION
Affects mainly immutable_data_manager.rs.

This implements a list of "full" PmidNodes at the IDM, so that they can block Put requests if too many close nodes are full.  No tests are in place for this at the moment.  The remaining changes are due to dependency updates and running rustfmt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/403) &emsp; Multiple assignees:&emsp;<img alt="@brian-js" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/623265?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/brian-js">brian-js</a>,&emsp;<img alt="@dirvine" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/123627?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/dirvine">dirvine</a>,&emsp;<img alt="@maqi" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/568777?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/maqi">maqi</a>
<!-- Reviewable:end -->
