### PR TITLE
WIP SDM refresh message having a message_id

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use personas::{immutable_data_manager, maid_manager, pmid_manager, mpid_manager};
-use routing::{PlainData, StructuredData};
+use routing::{MessageId, PlainData, StructuredData};
 use xor_name::XorName;
 
 #[derive(Debug, Clone, Eq, PartialEq, RustcEncodable, RustcDecodable)]
@@ -38,7 +38,7 @@ impl Refresh {
 pub enum RefreshValue {
     MaidManagerAccount(maid_manager::Account),
     ImmutableDataManagerAccount(immutable_data_manager::Account),
-    StructuredDataManager(StructuredData),
+    StructuredDataManager(StructuredData, MessageId),
     PmidManagerAccount(pmid_manager::Account),
     // mpid_manager: account, outbox messages, inbox headers
     MpidManagerAccount(mpid_manager::Account, Vec<PlainData>, Vec<PlainData>),

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -402,7 +402,7 @@ impl Vault {
                      -> Result<(), InternalError> {
         self.maid_manager.handle_churn(routing_node);
         self.immutable_data_manager.handle_node_added(routing_node, node_added);
-        self.structured_data_manager.handle_churn(routing_node);
+        self.structured_data_manager.handle_churn(routing_node, node_added);
         self.pmid_manager.handle_churn(routing_node);
         self.pmid_node.handle_churn(routing_node);
         self.mpid_manager.handle_churn(routing_node);
@@ -416,7 +416,7 @@ impl Vault {
         let _ = self.full_pmid_nodes.remove(&node_lost);
         self.maid_manager.handle_churn(routing_node);
         self.immutable_data_manager.handle_node_lost(routing_node, node_lost);
-        self.structured_data_manager.handle_churn(routing_node);
+        self.structured_data_manager.handle_churn(routing_node, node_lost);
         self.pmid_manager.handle_churn(routing_node);
         self.pmid_node.handle_churn(routing_node);
         self.mpid_manager.handle_churn(routing_node);
@@ -462,7 +462,7 @@ impl Vault {
             }
             (&Authority::NaeManager(_),
              &Authority::NaeManager(_),
-             &RefreshValue::StructuredDataManager(ref structured_data)) => {
+             &RefreshValue::StructuredDataManager(ref structured_data, _)) => {
                 self.structured_data_manager.handle_refresh(structured_data.clone())
             }
             (&Authority::NodeManager(_),


### PR DESCRIPTION
Affects: vault.rs types.rs structured_data_manager.rs

deduce a message_id from the churn node and use it in the refresh message of SDM,
to avoid a sd chunk's refreshing message being identical among different churns,
and be blocked in routing accumulator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/411) &emsp; Multiple assignees:&emsp;<img alt="@Fraser999" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/190532?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/Fraser999">Fraser999</a>,&emsp;<img alt="@brian-js" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/623265?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/brian-js">brian-js</a>,&emsp;<img alt="@dirvine" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/123627?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/dirvine">dirvine</a>
<!-- Reviewable:end -->
