### PR TITLE
Network fullness check and project structure update..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@ target/
 /.project
 *.sublime-*
 *.bootstrap.cache
-/bin/*
-!safe_vault.rs
+/bin/
 .cargo/
 packages/
 .DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ctrlc = "~1.1.1"
 docopt = "~0.6.78"
 log = "~0.3.6"
 maidsafe_utilities = "~0.5.1"
-routing = "~0.13.0"
+routing = "~0.14.0"
 rustc-serialize = "~0.3.19"
 safe_network_common = "~0.1.1"
 sodiumoxide = "~0.0.10"
@@ -28,7 +28,7 @@ xor_name = "~0.1.0"
 [dev-dependencies]
 kademlia_routing_table = "~0.4.0"
 rand = "~0.3.14"
-safe_core = "~0.14.0"
+safe_core = "~0.14.1"
 
 [build-dependencies]
 hyper = {version = "~0.8.0", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,6 @@ repository = "https://github.com/maidsafe/safe_vault"
 version = "0.5.0"
 build = "build.rs"
 
-[[bin]]
-name = "safe_vault"
-path = "bin/safe_vault.rs"
-
-[lib]
-name = "vault"
-path = "src/lib.rs"
-
 [dependencies]
 chunk_store = "~0.3.0"
 clippy = {version = "~0.0.62", optional = true}

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -58,12 +58,12 @@ extern crate maidsafe_utilities;
 extern crate config_file_handler;
 extern crate docopt;
 extern crate rustc_serialize;
-extern crate vault;
+extern crate safe_vault;
 
 use std::ffi::OsString;
 use std::process;
 use docopt::Docopt;
-use vault::Vault;
+use safe_vault::Vault;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 static USAGE: &'static str = "

--- a/src/personas/maid_manager.rs
+++ b/src/personas/maid_manager.rs
@@ -784,6 +784,7 @@ mod test {
 
         if let Ok(Some(close_group)) = env.routing.close_group(utils::client_name(&env.client)) {
             full_pmid_nodes = close_group.iter()
+                                         .take(close_group.len() / 2)
                                          .cloned()
                                          .collect::<HashSet<XorName>>();
         }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -251,7 +251,7 @@ impl Vault {
             (&Authority::Client { .. },
              &Authority::ClientManager(_),
              &RequestContent::Put(Data::Structured(_), _)) => {
-                self.maid_manager.handle_put(routing_node, &request)
+                self.maid_manager.handle_put(routing_node, &self.full_pmid_nodes, &request)
             }
             (&Authority::Client { .. },
              &Authority::ClientManager(_),

--- a/tests/mock_crust.rs
+++ b/tests/mock_crust.rs
@@ -36,7 +36,7 @@ extern crate rand;
 extern crate routing;
 extern crate sodiumoxide;
 extern crate xor_name;
-extern crate vault;
+extern crate safe_vault;
 
 #[cfg(feature = "use-mock-crust")]
 mod mock_crust_detail;

--- a/tests/mock_crust_detail/test_node.rs
+++ b/tests/mock_crust_detail/test_node.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use routing::mock_crust::{self, Endpoint, Network, ServiceHandle};
-use vault::{Config, Vault};
+use safe_vault::{Config, Vault};
 use xor_name::XorName;
 
 use super::poll;


### PR DESCRIPTION
Check network state at MaidManager and rework project structure.

On a Put request from a Client compare close group with full pmid nodes
returning failure if 50% or more close nodes are present.
Moved bin folder to src/bin in line with recommended directory structure. Use default safe_vault name for lib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/412) &emsp; Multiple assignees:&emsp;<img alt="@Fraser999" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/190532?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/Fraser999">Fraser999</a>,&emsp;<img alt="@dirvine" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/123627?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/dirvine">dirvine</a>,&emsp;<img alt="@maqi" height="20" width="20" align="absmiddle" src="https://avatars.githubusercontent.com/u/568777?s=40&v=3">&nbsp;<a href="/maidsafe/safe_vault/pulls/assigned/maqi">maqi</a>
<!-- Reviewable:end -->
