### PR TITLE
Expand CI scripts to automatically build and deploy release binaries ("rust-everywhere")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: generic
 # Env variables:
 #
 #   TARGET:      target triplet
+#   PLATFORM:    platform suffix for the release file name (e.g. linux-x64)
 #   CHANNEL:     rust channel: stable/beta/nightly. If not specified, defaults
 #                to stable.
 #   FEATURES:    build with --features "$FEATURES". Will also build (but not
@@ -23,17 +24,32 @@ env:
 matrix:
   include:
     - os: linux
-      env: TARGET=x86_64-unknown-linux-gnu FEATURES=use-mock-crust
+      env: >
+        TARGET=x86_64-unknown-linux-gnu
+        PLATFORM=linux-x64
+        FEATURES=use-mock-crust
 
     # TODO: Figure out cross-compilation and uncomment these:
     # - os: linux
-    #   env: TARGET=i686-unknown-linux-gnu FEATURES=use-mock-crust ONLY_DEPLOY=1
+    #   env: >
+    #     TARGET=i686-unknown-linux-gnu
+    #     PLATFORM=linux-x86
+    #     FEATURES=use-mock-crust
+    #     ONLY_DEPLOY=1
 
     # - os: linux
-    #   env: TARGET=x86_64-unknown-linux-musl FEATURES=use-mock-crust ONLY_DEPLOY=1
+    #   env: >
+    #     TARGET=x86_64-unknown-linux-musl
+    #     PLATFORM=linux-musl-x64
+    #     FEATURES=use-mock-crust
+    #     ONLY_DEPLOY=1
 
     # - os: linux
-    #   env: TARGET=armv7-unknown-linux-gnueabihf FEATURES=use-mock-crust ONLY_DEPLOY=1
+    #   env: >
+    #     TARGET=armv7-unknown-linux-gnueabihf
+    #     PLATFORM=armv7
+    #     FEATURES=use-mock-crust
+    #     ONLY_DEPLOY=1
     #   # Extra packages only for this job
     #   addons:
     #     apt:
@@ -47,14 +63,21 @@ matrix:
     #         - binfmt-support
 
     - os: linux
-      env: CHANNEL=nightly FEATURES="clippy use-mock-crust"
+      env: >
+        CHANNEL=nightly
+        FEATURES="clippy use-mock-crust"
       allow_failures: true
 
     - os: osx
-      env: TARGET=x86_64-apple-darwin FEATURES=use-mock-crust
+      env: >
+        TARGET=x86_64-apple-darwin
+        PLATFORM=osx-x64
+        FEATURES=use-mock-crust
 
     - os: osx
-      env: CHANNEL=nightly FEATURES="clippy use-mock-crust"
+      env: >
+        CHANNEL=nightly
+        FEATURES="clippy use-mock-crust"
       allow_failures: true
 
   # Add "allow_failures: true" to rows which are allowed to fail without making
@@ -107,10 +130,10 @@ deploy:
   api_key:
     secure: "jYtMFjw2vGqiakmUOH9H/4lN+iPDwtG2IoCTsGF8Jn5c74pebASN5so6nDkGhyZuo52hM1Q60xvhJU0eblA+7ryv2JV1kEnINFuJ31bnWf81oSEGmN3aEla2OWZe/nS8taVbIYEYA2DqNQeo6UX/sMUTCrWbh1VGnqNiWQv6j/wuAEKRlNVFqhnA42zsbTtX+Jzr+hdnrs33GbnRl8geDjDuqGb7Pk6FdDPysALuQmwRsrj3/IG6k/1AMDtFf8RSD0hFezoNvwq2k9b1iji5hJJDOAjHL74XDRGWg4dZovw1ImFSSeuHg86uRyxFj3b3OgP4MS32UxLQJ+yZvlKLOJ09AWBYmEpNdFL+GX4UIr99NMhT/5CPJNtWed8Lttr3p3RZCFVMNMWHFkI7aNbGZr0OVdDvX0zsRvKt+SPBB0N7EGlGaUKNiL6DuPMRLr0xSN224dsY8TTlfWWPYc3NYNaeRAFLGx7OZIlcB1S95zElgJD16DPTiGg9gs/8R10zKWcqklprvFF5f9yg53Fbuq6xrwhPWoRKFCVQjgBvKedTWtnYxu1RrtF7IuesGFWVK8I/6OJw5IIdvSy2ieDdXehZQoyw1LQQ4smwAZQjCdwfaCBZarSeqi2yYMRx+QZicUHEQM8G+GafhMEYDC8zRRTxvqTGgu79chFxczhcpJI="
 
-  file: ${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz
+  file: ${PROJECT_NAME}-${TRAVIS_TAG}-${PLATFORM}.tar.gz
   skip_cleanup: true
   draft: true
   tag_name: ${TRAVIS_TAG}
   on:
       tags: true
-      condition: (-n "$TARGET") && ("${CHANNEL:-stable}"=stable)
+      condition: (-n "$PLATFORM") && ("${CHANNEL:-stable}"=stable)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ language: generic
 
 env:
   global:
-    - secure: GXW0WyMkipF5lh29QHMxSKl6Dpvd4Qqggu5SBGymS5KQ7VPuqgEE2A8YwQDIGf4IEZUoAcAb1W7oPwQ0/kv7omlF2S8gmals1BeGKStU1np6lIIH64B87w4RIDhD+limVAfKgWb3Oldj6PDAm8gjbWjPiZF/6oxH4hd/+d9r2GY=
+    # TODO: set correct token
+    # - secure: GXW0WyMkipF5lh29QHMxSKl6Dpvd4Qqggu5SBGymS5KQ7VPuqgEE2A8YwQDIGf4IEZUoAcAb1W7oPwQ0/kv7omlF2S8gmals1BeGKStU1np6lIIH64B87w4RIDhD+limVAfKgWb3Oldj6PDAm8gjbWjPiZF/6oxH4hd/+d9r2GY=
+    - secure: "bvyT7ztCuuv1Itqk2Axb9DYxP4Y9ezAFWfWfHxjlU2Of3AY6hduWsizfjq4gWvh8uTkvgsI36UhMnQwpWmdmdwExHF88Yl7ex2vchXPyQZo2agECzf32fFURbKlsAjiOSotbzC1kCE6kdMITLe2hhaE35q0d9A4zF65sXs3ytdaPNGv/q8kUCCfQnvxwX7pJ8I0JO8BBSSy30KRk8ttxozRED5zO2WmUzgZ7SJrAH0bBncLz9xlQ2TrT40p5mKRaS2R4Dpchxp3pxwKLMzuODbF50BOWwAuwNq3HO3rfk3IJXxGUjWPicrzpBl/nc2Ku63vAaEtZ+WIeDTzMgOYwU/pvxBKNy465uUmTWblQUyBTQo+DpGP9AXTO2FiMo8eI9qRnNqYjugiCgCwV0q0bfTz5a/fO7NAptpSNlojKZasGH2E6lUlvPp5oKDhhWc7JJ+Jb0CNZoAq8Qwo2KhpiM7YZstuaKkUvNlm304pAcyPausHouuWDkWKnDynT7LLbnGT1KgDXgEk/NKuCK+eH6GSOZ2ohrWOszyxR8iRhuEyH//Zp7Z99w2TJAYuP1ZYKHoFPmq57tPkGgfhabAz9OlVpWPaTesZg73GGqFeSgC7ePMv5jTTFIPYb7PN0rkSNKSRLM5xwhUOqs+Bs7/hW+4ibbm6wnVMkeqoZZWO5NO8="
     - PROJECT_NAME=safe_vault
     - LibSodiumVersion=1.0.9
 
@@ -89,11 +91,9 @@ matrix:
 
 branches:
   only:
-    # Pushes and PRs to the master branch
-    - master
-    # Pushes to tags (will trigger deploy)
-    # This regex matches semantic versions like v1.2.3-rc4+2016.02.22
-    - /^v\d+\.\d+\.\d+.*$/
+    # TODO: switch to master once we are done testing
+    # - master
+    - autorelease
 
 cache:
   directories:
@@ -101,6 +101,7 @@ cache:
     - $HOME/.cargo
 
 before_install:
+  - export PROJECT_VERSION=$(git log -1 | grep -i "version change to" | sed "s/.*[vV]ersion change to v\{0,1\}//")
   - export PATH="$PATH:$HOME/.cargo/bin"
   - export PKG_CONFIG_PATH="$HOME/libsodium/$LibSodiumVersion/lib/pkgconfig:$PKG_CONFIG_PATH"
   - export PKG_CONFIG_ALLOW_CROSS=1
@@ -117,23 +118,14 @@ after_success:
 before_deploy:
   - ./ci/travis/before_deploy.sh
 
-# Deploy happens only when pushing a tag and only for stable rust.
 deploy:
   provider: releases
-
-  # TODO Regenerate this api_key for your project, this one won't work for you. Here's how:
-  # - Go to 'https://github.com/settings/tokens/new' and generate a Token with only the
-  # `public_repo` scope enabled
-  # - Call `travis encrypt $github_token` where $github_token is the token you got in the previous
-  # step and `travis` is the official Travis CI gem (see https://rubygems.org/gems/travis/)
-  # - Enter the "encrypted value" below
-  api_key:
-    secure: "jYtMFjw2vGqiakmUOH9H/4lN+iPDwtG2IoCTsGF8Jn5c74pebASN5so6nDkGhyZuo52hM1Q60xvhJU0eblA+7ryv2JV1kEnINFuJ31bnWf81oSEGmN3aEla2OWZe/nS8taVbIYEYA2DqNQeo6UX/sMUTCrWbh1VGnqNiWQv6j/wuAEKRlNVFqhnA42zsbTtX+Jzr+hdnrs33GbnRl8geDjDuqGb7Pk6FdDPysALuQmwRsrj3/IG6k/1AMDtFf8RSD0hFezoNvwq2k9b1iji5hJJDOAjHL74XDRGWg4dZovw1ImFSSeuHg86uRyxFj3b3OgP4MS32UxLQJ+yZvlKLOJ09AWBYmEpNdFL+GX4UIr99NMhT/5CPJNtWed8Lttr3p3RZCFVMNMWHFkI7aNbGZr0OVdDvX0zsRvKt+SPBB0N7EGlGaUKNiL6DuPMRLr0xSN224dsY8TTlfWWPYc3NYNaeRAFLGx7OZIlcB1S95zElgJD16DPTiGg9gs/8R10zKWcqklprvFF5f9yg53Fbuq6xrwhPWoRKFCVQjgBvKedTWtnYxu1RrtF7IuesGFWVK8I/6OJw5IIdvSy2ieDdXehZQoyw1LQQ4smwAZQjCdwfaCBZarSeqi2yYMRx+QZicUHEQM8G+GafhMEYDC8zRRTxvqTGgu79chFxczhcpJI="
-
-  file: ${PROJECT_NAME}-${TRAVIS_TAG}-${PLATFORM}.tar.gz
+  api_key: ${GH_TOKEN}
+  file: ${PROJECT_NAME}-v${PROJECT_VERSION}-${PLATFORM}.tar.gz
   skip_cleanup: true
   draft: true
-  tag_name: ${TRAVIS_TAG}
+  tag_name: ${PROJECT_VERSION}
   on:
-      tags: true
-      condition: (-n "$PLATFORM") && ("${CHANNEL:-stable}"=stable)
+      # Deploy only on version bump commits (must contain "Version change to x.y.z"
+      # in the commit message), and only for stable rust.
+      condition: (-n "$PROJECT_VERSION") && (-n "$PLATFORM") && ("${CHANNEL:-stable}"=stable)

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ deploy:
   file: ${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz
   skip_cleanup: true
   draft: true
+  tag_name: ${TRAVIS_TAG}
   on:
       tags: true
       condition: (-n "$TARGET") && ("${CHANNEL:-stable}"=stable)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,11 @@ language: generic
 #   FEATURES:    build with --features "$FEATURES". Will also build (but not
 #                run) without those features.
 #   ONLY_DEPLOY: build this configuration only if we are deploying a release
-#                (pushing a tag).
+#                (on version bump).
 
 env:
   global:
-    # TODO: set correct token
-    # - secure: GXW0WyMkipF5lh29QHMxSKl6Dpvd4Qqggu5SBGymS5KQ7VPuqgEE2A8YwQDIGf4IEZUoAcAb1W7oPwQ0/kv7omlF2S8gmals1BeGKStU1np6lIIH64B87w4RIDhD+limVAfKgWb3Oldj6PDAm8gjbWjPiZF/6oxH4hd/+d9r2GY=
-    - secure: "bvyT7ztCuuv1Itqk2Axb9DYxP4Y9ezAFWfWfHxjlU2Of3AY6hduWsizfjq4gWvh8uTkvgsI36UhMnQwpWmdmdwExHF88Yl7ex2vchXPyQZo2agECzf32fFURbKlsAjiOSotbzC1kCE6kdMITLe2hhaE35q0d9A4zF65sXs3ytdaPNGv/q8kUCCfQnvxwX7pJ8I0JO8BBSSy30KRk8ttxozRED5zO2WmUzgZ7SJrAH0bBncLz9xlQ2TrT40p5mKRaS2R4Dpchxp3pxwKLMzuODbF50BOWwAuwNq3HO3rfk3IJXxGUjWPicrzpBl/nc2Ku63vAaEtZ+WIeDTzMgOYwU/pvxBKNy465uUmTWblQUyBTQo+DpGP9AXTO2FiMo8eI9qRnNqYjugiCgCwV0q0bfTz5a/fO7NAptpSNlojKZasGH2E6lUlvPp5oKDhhWc7JJ+Jb0CNZoAq8Qwo2KhpiM7YZstuaKkUvNlm304pAcyPausHouuWDkWKnDynT7LLbnGT1KgDXgEk/NKuCK+eH6GSOZ2ohrWOszyxR8iRhuEyH//Zp7Z99w2TJAYuP1ZYKHoFPmq57tPkGgfhabAz9OlVpWPaTesZg73GGqFeSgC7ePMv5jTTFIPYb7PN0rkSNKSRLM5xwhUOqs+Bs7/hW+4ibbm6wnVMkeqoZZWO5NO8="
+    - secure: GXW0WyMkipF5lh29QHMxSKl6Dpvd4Qqggu5SBGymS5KQ7VPuqgEE2A8YwQDIGf4IEZUoAcAb1W7oPwQ0/kv7omlF2S8gmals1BeGKStU1np6lIIH64B87w4RIDhD+limVAfKgWb3Oldj6PDAm8gjbWjPiZF/6oxH4hd/+d9r2GY=
     - PROJECT_NAME=safe_vault
     - LibSodiumVersion=1.0.9
 
@@ -91,9 +89,7 @@ matrix:
 
 branches:
   only:
-    # TODO: switch to master once we are done testing
-    # - master
-    - autorelease
+    - master
 
 cache:
   directories:
@@ -126,6 +122,6 @@ deploy:
   draft: true
   tag_name: ${PROJECT_VERSION}
   on:
-      # Deploy only on version bump commits (must contain "Version change to x.y.z"
-      # in the commit message), and only for stable rust.
-      condition: (-n "$PROJECT_VERSION") && (-n "$PLATFORM") && ("${CHANNEL:-stable}"=stable)
+    # Deploy only on version bump commits (must contain "Version change to x.y.z"
+    # in the commit message), and only for stable rust.
+    condition: (-n "$PROJECT_VERSION") && (-n "$PLATFORM") && ("${CHANNEL:-stable}"=stable)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,115 @@
+sudo: false
+# Note: cannot use "rust" here, because that doesn't give us the "rustup"
+# binary, which we need for cross-compilation.
+# As a workaround, we use "generic" and install the rust ecosystem ourselves.
+language: generic
+
+# Env variables:
+#
+#   TARGET:      target triplet
+#   CHANNEL:     rust channel: stable/beta/nightly. If not specified, defaults
+#                to stable.
+#   FEATURES:    build with --features "$FEATURES". Will also build (but not
+#                run) without those features.
+#   ONLY_DEPLOY: build this configuration only if we are deploying a release
+#                (pushing a tag).
+
 env:
   global:
     - secure: GXW0WyMkipF5lh29QHMxSKl6Dpvd4Qqggu5SBGymS5KQ7VPuqgEE2A8YwQDIGf4IEZUoAcAb1W7oPwQ0/kv7omlF2S8gmals1BeGKStU1np6lIIH64B87w4RIDhD+limVAfKgWb3Oldj6PDAm8gjbWjPiZF/6oxH4hd/+d9r2GY=
-    - Features="use-mock-crust"
-os:
-  - linux
-  - osx
-language: rust
-rust:
-  - stable
-  - nightly
-sudo: false
+    - PROJECT_NAME=safe_vault
+    - LibSodiumVersion=1.0.9
+
+matrix:
+  include:
+    - os: linux
+      env: TARGET=x86_64-unknown-linux-gnu FEATURES=use-mock-crust
+
+    # TODO: Figure out cross-compilation and uncomment these:
+    # - os: linux
+    #   env: TARGET=i686-unknown-linux-gnu FEATURES=use-mock-crust ONLY_DEPLOY=1
+
+    # - os: linux
+    #   env: TARGET=x86_64-unknown-linux-musl FEATURES=use-mock-crust ONLY_DEPLOY=1
+
+    # - os: linux
+    #   env: TARGET=armv7-unknown-linux-gnueabihf FEATURES=use-mock-crust ONLY_DEPLOY=1
+    #   # Extra packages only for this job
+    #   addons:
+    #     apt:
+    #       packages:
+    #         # Cross compiler and cross compiled C libraries
+    #         - gcc-arm-linux-gnueabihf
+    #         - libc6-armhf-cross
+    #         - libc6-dev-armhf-cross
+    #         # Transparent emulation
+    #         - qemu-user-static
+    #         - binfmt-support
+
+    - os: linux
+      env: CHANNEL=nightly FEATURES="clippy use-mock-crust"
+      allow_failures: true
+
+    - os: osx
+      env: TARGET=x86_64-apple-darwin FEATURES=use-mock-crust
+
+    - os: osx
+      env: CHANNEL=nightly FEATURES="clippy use-mock-crust"
+      allow_failures: true
+
+  # Add "allow_failures: true" to rows which are allowed to fail without making
+  # the whole build fail. This is useful for nightly builds.
+  allow_failures:
+    - allow_failures: true
+  # Don't wait for the rows that are allowed to fail.
+  fast_finish: true
+
 branches:
   only:
+    # Pushes and PRs to the master branch
     - master
+    # Pushes to tags (will trigger deploy)
+    # This regex matches semantic versions like v1.2.3-rc4+2016.02.22
+    - /^v\d+\.\d+\.\d+.*$/
+
 cache:
   directories:
     - $HOME/libsodium
-    - $HOME/elfutils
+    - $HOME/.cargo
+
+before_install:
+  - export PATH="$PATH:$HOME/.cargo/bin"
+  - export PKG_CONFIG_PATH="$HOME/libsodium/$LibSodiumVersion/lib/pkgconfig:$PKG_CONFIG_PATH"
+  - export PKG_CONFIG_ALLOW_CROSS=1
+
 install:
-  - curl -sSLO https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/install_libsodium.sh
-  - . install_libsodium.sh
+  - ./ci/travis/install.sh
+
 script:
-  - curl -sSL https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/build_and_run_tests.sh | bash
-  - cd $TRAVIS_BUILD_DIR
-#  - cargo test --release --no-run;
-before_cache:
-  - curl -sSLO https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/install_elfutils.sh
-  - . install_elfutils.sh
+  - ./ci/travis/script.sh
+
 after_success:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/after_success.sh | bash
+
+before_deploy:
+  - ./ci/travis/before_deploy.sh
+
+# Deploy happens only when pushing a tag and only for stable rust.
+deploy:
+  provider: releases
+
+  # TODO Regenerate this api_key for your project, this one won't work for you. Here's how:
+  # - Go to 'https://github.com/settings/tokens/new' and generate a Token with only the
+  # `public_repo` scope enabled
+  # - Call `travis encrypt $github_token` where $github_token is the token you got in the previous
+  # step and `travis` is the official Travis CI gem (see https://rubygems.org/gems/travis/)
+  # - Enter the "encrypted value" below
+  api_key:
+    secure: "jYtMFjw2vGqiakmUOH9H/4lN+iPDwtG2IoCTsGF8Jn5c74pebASN5so6nDkGhyZuo52hM1Q60xvhJU0eblA+7ryv2JV1kEnINFuJ31bnWf81oSEGmN3aEla2OWZe/nS8taVbIYEYA2DqNQeo6UX/sMUTCrWbh1VGnqNiWQv6j/wuAEKRlNVFqhnA42zsbTtX+Jzr+hdnrs33GbnRl8geDjDuqGb7Pk6FdDPysALuQmwRsrj3/IG6k/1AMDtFf8RSD0hFezoNvwq2k9b1iji5hJJDOAjHL74XDRGWg4dZovw1ImFSSeuHg86uRyxFj3b3OgP4MS32UxLQJ+yZvlKLOJ09AWBYmEpNdFL+GX4UIr99NMhT/5CPJNtWed8Lttr3p3RZCFVMNMWHFkI7aNbGZr0OVdDvX0zsRvKt+SPBB0N7EGlGaUKNiL6DuPMRLr0xSN224dsY8TTlfWWPYc3NYNaeRAFLGx7OZIlcB1S95zElgJD16DPTiGg9gs/8R10zKWcqklprvFF5f9yg53Fbuq6xrwhPWoRKFCVQjgBvKedTWtnYxu1RrtF7IuesGFWVK8I/6OJw5IIdvSy2ieDdXehZQoyw1LQQ4smwAZQjCdwfaCBZarSeqi2yYMRx+QZicUHEQM8G+GafhMEYDC8zRRTxvqTGgu79chFxczhcpJI="
+
+  file: ${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz
+  skip_cleanup: true
+  draft: true
+  on:
+      tags: true
+      condition: (-n "$TARGET") && ("${CHANNEL:-stable}"=stable)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,7 @@ environment:
     - RUST_VERSION: stable
 branches:
   only:
-    # TODO: switch to master once we are done testing
-    # - master
-    - autorelease
+    - master
 
 clone_depth: 50
 skip_tags: true
@@ -55,11 +53,11 @@ before_deploy:
 
 deploy:
   provider: GitHub
-  tag: $(PROJECT_VERSION)
-  draft: true
+  auth_token: $(GH_TOKEN)
   # All the zipped artifacts will be deployed
   artifact: /.*\.zip/
-  auth_token: $(GH_TOKEN)
+  draft: true
+  tag: $(PROJECT_VERSION)
   on:
     DEPLOY: true
     RUST_VERSION: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   global:
     RUST_BACKTRACE: 1
+    PROJECT_NAME: safe_vault
   matrix:
     - RUST_VERSION: stable
 branches:
@@ -26,7 +27,6 @@ platform:
   - x64
 
 configuration:
-#  - Debug
   - Release
 
 build_script:
@@ -34,3 +34,32 @@ build_script:
 
 test_script:
   - ps: . ".\Run Tests.ps1"
+
+before_deploy:
+  # Generate artifacts for release
+  - cargo build --release
+  - mkdir staging
+  - copy target\release\%PROJECT_NAME%.exe staging
+  - copy installer\common\%PROJECT_NAME%.crust.config staging
+  - copy installer\common\%PROJECT_NAME%.vault.config staging
+  - cd staging
+  - 7z a ../%PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%-%PLATFORM%.zip *
+  - appveyor PushArtifact ../%PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%-%PLATFORM%.zip
+
+deploy:
+  provider: GitHub
+  description: "Windows release"
+  draft: true
+  # All the zipped artifacts will be deployed
+  artifact: /.*\.zip/
+  # TODO Regenerate this auth_token for your project, this one won't work for you. Here's how:
+  # - Go to 'https://github.com/settings/tokens/new' and generate a Token with only the
+  # `public_repo` scope enabled
+  # - Then go to 'https://ci.appveyor.com/tools/encrypt' and enter the newly generated token.
+  # - Enter the "encrypted value" below
+  auth_token:
+    secure: C4JKw8gII6/XApU2VRAesM3kwYWVDez1qxsiqu7Jfzgfo7SlNCA1MmXGGgKne9QC
+  # deploy when a new tag is pushed and only on the stable channel
+  on:
+    RUST_VERSION: stable
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,7 @@
 environment:
   global:
     GH_TOKEN:
-      # TODO Regenerate this auth_token for your project, this one won't work for you. Here's how:
-      # - Go to 'https://github.com/settings/tokens/new' and generate a Token with only the
-      # `public_repo` scope enabled
-      # - Then go to 'https://ci.appveyor.com/tools/encrypt' and enter the newly generated token.
-      # - Enter the "encrypted value" below
-      secure: ipSdOqm+lOjEMrx4ABEQkxlQ/9x/aEmx0fRVqr7rC335sS24z+t/9/fFQKWBx3wV
+      secure: Plf6CbvLc5BWpB51EU9Sk/RMow47fZp74uSKt1Wv20kFRf1OQS2pVuEzgXQPuyhW
     PROJECT_NAME: safe_vault
     RUST_BACKTRACE: 1
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,24 @@
 environment:
   global:
-    RUST_BACKTRACE: 1
+    GH_TOKEN:
+      # TODO Regenerate this auth_token for your project, this one won't work for you. Here's how:
+      # - Go to 'https://github.com/settings/tokens/new' and generate a Token with only the
+      # `public_repo` scope enabled
+      # - Then go to 'https://ci.appveyor.com/tools/encrypt' and enter the newly generated token.
+      # - Enter the "encrypted value" below
+      secure: ipSdOqm+lOjEMrx4ABEQkxlQ/9x/aEmx0fRVqr7rC335sS24z+t/9/fFQKWBx3wV
     PROJECT_NAME: safe_vault
+    RUST_BACKTRACE: 1
   matrix:
     - RUST_VERSION: stable
 branches:
   only:
-    - master
+    # TODO: switch to master once we are done testing
+    # - master
+    - autorelease
 
 clone_depth: 50
+skip_tags: true
 
 install:
   - ps: |
@@ -21,6 +31,11 @@ install:
         . ".\Install Rust.ps1"
         . ".\Install MinGW.ps1"
         . ".\Install libsodium.ps1"
+
+        if ($env:APPVEYOR_REPO_COMMIT_MESSAGE -match "[vV]ersion change to v?(.*)") {
+          $env:PROJECT_VERSION = $matches[1]
+          $env:DEPLOY = "true"
+        }
 
 platform:
   - x86
@@ -36,30 +51,15 @@ test_script:
   - ps: . ".\Run Tests.ps1"
 
 before_deploy:
-  # Generate artifacts for release
-  - cargo build --release
-  - mkdir staging
-  - copy target\release\%PROJECT_NAME%.exe staging
-  - copy installer\common\%PROJECT_NAME%.crust.config staging
-  - copy installer\common\%PROJECT_NAME%.vault.config staging
-  - cd staging
-  - 7z a ../%PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%-%PLATFORM%.zip *
-  - appveyor PushArtifact ../%PROJECT_NAME%-%APPVEYOR_REPO_TAG_NAME%-%PLATFORM%.zip
+  - ps: . ".\ci\appveyor\before_deploy.ps1"
 
 deploy:
   provider: GitHub
-  description: "Windows release"
+  tag: $(PROJECT_VERSION)
   draft: true
   # All the zipped artifacts will be deployed
   artifact: /.*\.zip/
-  # TODO Regenerate this auth_token for your project, this one won't work for you. Here's how:
-  # - Go to 'https://github.com/settings/tokens/new' and generate a Token with only the
-  # `public_repo` scope enabled
-  # - Then go to 'https://ci.appveyor.com/tools/encrypt' and enter the newly generated token.
-  # - Enter the "encrypted value" below
-  auth_token:
-    secure: C4JKw8gII6/XApU2VRAesM3kwYWVDez1qxsiqu7Jfzgfo7SlNCA1MmXGGgKne9QC
-  # deploy when a new tag is pushed and only on the stable channel
+  auth_token: $(GH_TOKEN)
   on:
+    DEPLOY: true
     RUST_VERSION: stable
-    appveyor_repo_tag: true

--- a/ci/appveyor/before_deploy.ps1
+++ b/ci/appveyor/before_deploy.ps1
@@ -1,0 +1,27 @@
+
+cargo build --release
+
+# Tag this commit if not already tagged.
+git config --global user.name MaidSafe-QA
+git config --global user.email qa@maidsafe.net
+git fetch --tags
+
+if (git tag -l "$env:PROJECT_VERSION") {
+  echo "Tag $env:PROJECT_VERSION already exists"
+} else {
+  echo "Creating tag $env:PROJECT_VERSION"
+  git tag $env:PROJECT_VERSION -am "Version $env:PROJECT_VERSION" $APPVEYOR_REPO_COMMIT
+  git push "https://$env:GH_TOKEN@github.com/$env:APPVEYOR_REPO_NAME" tag $env:PROJECT_VERSION
+}
+
+# Create the release archive
+$NAME = "$env:PROJECT_NAME-v$env:PROJECT_VERSION-windows-$env:PLATFORM"
+
+New-Item -ItemType directory -Path staging
+New-Item -ItemType directory -Path staging\$NAME
+Copy-Item target\release\$env:PROJECT_NAME.exe staging\$NAME
+Copy-Item installer\bundle\* staging\$NAME
+
+cd staging
+7z a ../$NAME.zip *
+Push-AppveyorArtifact ../$NAME.zip

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -13,11 +13,14 @@ cargo build --target $TARGET --release
 TMP_DIR=$(mktempd)
 OUT_DIR=$(pwd)
 
-cp target/$TARGET/release/$PROJECT_NAME $TMP_DIR
-cp installer/common/*.config $TMP_DIR
+NAME=$PROJECT_NAME-$TRAVIS_TAG-$PLATFORM
+
+mkdir $TMP_DIR/$NAME
+cp target/$TARGET/release/$PROJECT_NAME $TMP_DIR/$NAME
+cp installer/bundle* $TMP_DIR/$NAME
 
 pushd $TMP_DIR
-tar czf $OUT_DIR/${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz *
+tar czf $OUT_DIR/$NAME.tar.gz *
 popd
 
 rm -r $TMP_DIR

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -ex
+# Print commands, but do not expand them (to not reveal secure tokens).
+set -ev
 
 # This works on both linux and osx
 mktempd() {
@@ -10,14 +11,25 @@ mktempd() {
 export RUST_BACKTRACE=1
 cargo build --target $TARGET --release
 
+# Tag this commit if not already tagged.
+git config --global user.name MaidSafe-QA
+git config --global user.email qa@maidsafe.net
+git fetch --tags
+
+if [ -z $(git tag -l "$PROJECT_VERSION") ]; then
+  git tag $PROJECT_VERSION -am "Version $PROJECT_VERSION" $TRAVIS_COMMIT
+  git push https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG} tag $PROJECT_VERSION > /dev/null 2>&1
+fi
+
+# Create the release archive
+NAME="$PROJECT_NAME-v$PROJECT_VERSION-$PLATFORM"
+
 TMP_DIR=$(mktempd)
 OUT_DIR=$(pwd)
 
-NAME=$PROJECT_NAME-$TRAVIS_TAG-$PLATFORM
-
 mkdir $TMP_DIR/$NAME
 cp target/$TARGET/release/$PROJECT_NAME $TMP_DIR/$NAME
-cp installer/bundle* $TMP_DIR/$NAME
+cp -r installer/bundle/* $TMP_DIR/$NAME
 
 pushd $TMP_DIR
 tar czf $OUT_DIR/$NAME.tar.gz *

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+# This works on both linux and osx
+mktempd() {
+  echo $(mktemp -d 2>/dev/null || mktemp -d -t tmp)
+}
+
+export RUST_BACKTRACE=1
+cargo build --target $TARGET --release
+
+TMP_DIR=$(mktempd)
+OUT_DIR=$(pwd)
+
+cp target/$TARGET/release/$PROJECT_NAME $TMP_DIR
+cp installer/common/*.config $TMP_DIR
+
+pushd $TMP_DIR
+tar czf $OUT_DIR/${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz *
+popd
+
+rm -r $TMP_DIR

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex
+
+CHANNEL=${CHANNEL:-stable}
+
+# Skip if $ONLY_DEPLOY is defined and this is not a deploy (that is, this build
+# was not triggered by pushing a tag).
+[ -n "$ONLY_DEPLOY" -a -z "$TRAVIS_TAG" ] && exit 0
+
+# Skip if this is a deploy, but rust channel is not stable.
+[ -n "$TRAVIS_TAG" -a "$CHANNEL" != stable ] && exit 0
+
+case "$TRAVIS_OS_NAME" in
+  linux)
+    HOST=x86_64-unknown-linux-gnu
+    ;;
+  osx)
+    HOST=x86_64-apple-darwin
+    ;;
+esac
+
+# Install libsodium
+(curl -sSLO https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/install_libsodium.sh &&
+ chmod a+x install_libsodium.sh &&
+ ./install_libsodium.sh)
+
+# Install rust
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=$CHANNEL
+rustc -V
+cargo -V
+
+# Install crates for cross-compilation
+if [ -n "$TARGET" -a "$HOST" != "$TARGET" ]; then
+  rustup target add $TARGET
+fi

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -ex
+
+CHANNEL=${CHANNEL:-stable}
+
+# Skip if $ONLY_DEPLOY is defined and this is not a deploy (that is, this build
+# was not triggered by pushing a tag).
+[ -n "$ONLY_DEPLOY" -a -z "$TRAVIS_TAG" ] && exit 0
+
+# Skip if this is a deploy, but rust channel is not stable.
+[ -n "$TRAVIS_TAG" -a "$CHANNEL" != stable ] && exit 0
+
+export RUST_BACKTRACE=1
+ARGS=()
+
+if [ -n "$FEATURES" ]; then
+  ARGS+=( --features "$FEATURES" )
+fi
+
+# Build and run tests with all features specified in $FEATURES
+cargo build --target "$TARGET" --release "${ARGS[@]}"
+cargo test --target "$TARGET" --release "${ARGS[@]}"
+
+# Also build (but don't run) without any features.
+if [ -n "$FEATURES" ]; then
+  cargo build --target "$TARGET" --release
+  cargo test --target "$TARGET" --release --no-run
+fi

--- a/installer/bundle/safe_vault.crust.config
+++ b/installer/bundle/safe_vault.crust.config
@@ -1,0 +1,80 @@
+{
+  "hard_coded_contacts": [
+    {
+      "tcp_acceptors": [
+        "45.55.207.180:5483"
+      ],
+      "utp_custom_listeners": [
+        "45.55.207.180:5483"
+      ],
+      "tcp_mapper_servers": [],
+      "udp_mapper_servers": []
+    },
+    {
+      "tcp_acceptors": [
+        "178.62.7.96:5483"
+      ],
+      "utp_custom_listeners": [
+        "178.62.7.96:5483"
+      ],
+      "tcp_mapper_servers": [],
+      "udp_mapper_servers": []
+    },
+    {
+      "tcp_acceptors": [
+        "128.199.199.210:5483"
+      ],
+      "utp_custom_listeners": [
+        "128.199.199.210:5483"
+      ],
+      "tcp_mapper_servers": [],
+      "udp_mapper_servers": []
+    },
+    {
+      "tcp_acceptors": [
+        "37.59.98.1:5483"
+      ],
+      "utp_custom_listeners": [
+        "37.59.98.1:5483"
+      ],
+      "tcp_mapper_servers": [],
+      "udp_mapper_servers": []
+    },
+    {
+      "tcp_acceptors": [
+        "45.79.93.11:5483"
+      ],
+      "utp_custom_listeners": [
+        "45.79.93.11:5483"
+      ],
+      "tcp_mapper_servers": [],
+      "udp_mapper_servers": []
+    },
+    {
+      "tcp_acceptors": [
+        "45.79.2.52:5483"
+      ],
+      "utp_custom_listeners": [
+        "45.79.2.52:5483"
+      ],
+      "tcp_mapper_servers": [],
+      "udp_mapper_servers": []
+    }
+  ],
+  "tcp_acceptor_port": null,
+  "utp_acceptor_port": null,
+  "tcp_mapper_servers": [
+    "162.243.228.81:39590",
+    "128.199.185.249:44473",
+    "178.62.82.189:46782"
+  ],
+  "udp_mapper_servers": [
+    "162.243.228.81:40953",
+    "128.199.185.249:54098",
+    "178.62.82.189:58616"
+  ],
+  "enable_tcp": true,
+  "enable_utp": true,
+  "service_discovery_port": null,
+  "bootstrap_cache_name": null
+}

--- a/installer/bundle/safe_vault.vault.config
+++ b/installer/bundle/safe_vault.vault.config
@@ -1,0 +1,4 @@
+{
+  "wallet_address": null,
+  "max_capacity": 104857600
+}


### PR DESCRIPTION
Travis and AppVeyor will build and publish binaries to Github releases each time a version bump commit is pushed (a commit whose message look like "Version changed to x.y.z").

Currently builds binaries for these platforms:

- linux x86_64 (64bit)
- osx x86_64 (64bit)
- windows x86_64 (64bit)
- windows i686 (32bit)

More platforms may be added later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/430)
<!-- Reviewable:end -->
