### PR TITLE
WIP: feat/event-handling: recreate routing or gracefully exit

### DIFF
--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -61,13 +61,12 @@ use safe_vault::Vault;
 #[cfg_attr(rustfmt, rustfmt_skip)]
 static USAGE: &'static str = "
 Usage:
-  safe_vault [--first | (--output=<file> [--first]) | --version | --help]
+  safe_vault [options]
 
 Options:
   -o <file>, --output=<file>    Direct log output to stderr _and_ <file>.  If
                                 <file> does not exist it will be created,
                                 otherwise it will be truncated.
-  -f, --first                   First vault on the local machine
   -V, --version                 Display version info and exit.
   -h, --help                    Display this help message and exit.
 ";
@@ -75,7 +74,6 @@ Options:
 #[derive(PartialEq, Eq, Debug, Clone, RustcDecodable)]
 struct Args {
     flag_output: Option<String>,
-    flag_first: bool,
     flag_version: bool,
     flag_help: bool,
 }
@@ -109,7 +107,7 @@ pub fn main() {
     info!("\n\n{}\n{}", message, underline);
 
     let mut vault = unwrap_result!(Vault::new());
-    unwrap_result!(vault.run(args.flag_first));
+    unwrap_result!(vault.run());
 }
 
 #[cfg(feature = "use-mock-crust")]

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -61,12 +61,13 @@ use safe_vault::Vault;
 #[cfg_attr(rustfmt, rustfmt_skip)]
 static USAGE: &'static str = "
 Usage:
-  safe_vault [options]
+  safe_vault [--first | (--output=<file> [--first]) | --version | --help]
 
 Options:
   -o <file>, --output=<file>    Direct log output to stderr _and_ <file>.  If
                                 <file> does not exist it will be created,
                                 otherwise it will be truncated.
+  -f, --first                   First vault on the local machine
   -V, --version                 Display version info and exit.
   -h, --help                    Display this help message and exit.
 ";
@@ -74,6 +75,7 @@ Options:
 #[derive(PartialEq, Eq, Debug, Clone, RustcDecodable)]
 struct Args {
     flag_output: Option<String>,
+    flag_first: bool,
     flag_version: bool,
     flag_help: bool,
 }
@@ -107,7 +109,7 @@ pub fn main() {
     info!("\n\n{}\n{}", message, underline);
 
     let mut vault = unwrap_result!(Vault::new());
-    unwrap_result!(vault.run());
+    unwrap_result!(vault.run(args.flag_first));
 }
 
 #[cfg(feature = "use-mock-crust")]

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -99,7 +99,7 @@ impl Vault {
 
     /// Run the event loop, processing events received from Routing.
     #[cfg(not(feature = "use-mock-crust"))]
-    pub fn run(&mut self) -> Result<(), InternalError> {
+    pub fn run(&mut self, is_first_node: bool) -> Result<(), InternalError> {
         let mut exit = false;
         while !exit {
             let (routing_sender, routing_receiver) = mpsc::channel();
@@ -107,7 +107,7 @@ impl Vault {
 
             for event in routing_receiver.iter() {
                 if let Some(terminate) = self.process_event(&routing_node, event) {
-                    exit = terminate;
+                    exit = terminate && is_first_node;
                     break;
                 }
             }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -99,7 +99,7 @@ impl Vault {
 
     /// Run the event loop, processing events received from Routing.
     #[cfg(not(feature = "use-mock-crust"))]
-    pub fn run(&mut self, is_first_node: bool) -> Result<(), InternalError> {
+    pub fn run(&mut self) -> Result<(), InternalError> {
         let mut exit = false;
         while !exit {
             let (routing_sender, routing_receiver) = mpsc::channel();
@@ -107,7 +107,7 @@ impl Vault {
 
             for event in routing_receiver.iter() {
                 if let Some(terminate) = self.process_event(&routing_node, event) {
-                    exit = terminate && is_first_node;
+                    exit = terminate;
                     break;
                 }
             }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -161,7 +161,7 @@ impl Vault {
                 ret = Some(false);
                 Ok(())
             }
-            Event::StartListeningFailed => {
+            Event::NetworkStartupFailed => {
                 ret = Some(true);
                 Ok(())
             }


### PR DESCRIPTION
On receiving events which indicate failed get for a network name (as a part of relocation process) or disconnection, dump the old routing object and recreate a new one.
On receiving event which indicates failure to listen for peers, exit the process gracefully as there is nothing much that can be done - i.e. vault can no longer connect to other anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/435)
<!-- Reviewable:end -->
