### PR TITLE
test/fill_network: re-enable integration test

### DIFF
--- a/tests/mock_crust.rs
+++ b/tests/mock_crust.rs
@@ -323,10 +323,6 @@ mod test {
         trace!("Processed {} events.", event_count);
     }
 
-    // FIXME - re-enable once the hard-coded `max_capacity` is removed from vault.rs
-    #[ignore]
-    // TODO: This is still flaky and occasionally fails with `Err(Empty)` in
-    // `TestClient::put_and_verify`.
     #[test]
     fn fill_network() {
         let network = Network::new();

--- a/tests/mock_crust_detail/test_node.rs
+++ b/tests/mock_crust_detail/test_node.rs
@@ -30,10 +30,13 @@ pub struct TestNode {
 impl TestNode {
     pub fn new(network: &Network,
                crust_config: Option<mock_crust::Config>,
-               _config: Option<Config>)
+               config: Option<Config>)
                -> Self {
         let handle = network.new_service_handle(crust_config, None);
-        let vault = mock_crust::make_current(&handle, || unwrap_result!(Vault::new()));
+        let mut vault = mock_crust::make_current(&handle, || unwrap_result!(Vault::new()));
+        if let Some(replacement_config) = config {
+            unwrap_result!(vault.apply_config(replacement_config));
+        }
 
         TestNode {
             handle: handle,


### PR DESCRIPTION
This re-enables the integration test which checks that Clients are sent appropriate failure messages
when the network's storage limit is reached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/446)
<!-- Reviewable:end -->
