### PR TITLE
chore/docs: clean the build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.8.0"
 [dependencies]
 accumulator = "~0.3.0"
 chunk_store = "~0.4.0"
-clippy = {version = "~0.0.64", optional = true}
+clippy = {version = "~0.0.66", optional = true}
 config_file_handler = "~0.3.0"
 docopt = "~0.6.80"
 itertools = "~0.4.13"
@@ -21,14 +21,14 @@ kademlia_routing_table = "~0.5.1"
 log = "~0.3.6"
 maidsafe_utilities = "~0.5.4"
 rand = "~0.3.14"
-routing = "~0.18.4"
+routing = "~0.18.5"
 rustc-serialize = "~0.3.19"
 safe_network_common = "~0.1.1"
 sodiumoxide = "~0.0.10"
 xor_name = "~0.1.0"
 
 [build-dependencies]
-hyper = {version = "~0.9.1", optional = true}
+hyper = {version = "~0.9.4", optional = true}
 
 [features]
 generate-diagrams = ["hyper"]

--- a/build.rs
+++ b/build.rs
@@ -27,53 +27,48 @@
 extern crate hyper;
 
 #[cfg(feature = "generate-diagrams")]
-use hyper::Client;
-#[cfg(feature = "generate-diagrams")]
-use hyper::client::IntoUrl;
-#[cfg(feature = "generate-diagrams")]
-use std::fs::{self, File};
-#[cfg(feature = "generate-diagrams")]
-use std::io;
-#[cfg(feature = "generate-diagrams")]
-use std::path::{Path, PathBuf};
+mod generate_diagrams {
+    use hyper::Client;
+    use hyper::client::IntoUrl;
+    use std::fs::{self, File};
+    use std::io;
+    use std::path::{Path, PathBuf};
+
+    pub fn download_image<U: IntoUrl>(name: &str, src: U) {
+        download(src, image_path(name))
+    }
+
+    fn download<U: IntoUrl, P: AsRef<Path>>(src: U, dst: P) {
+        let client = Client::new();
+        let mut res = client.get(src).send().unwrap();
+
+        if let Some(dir) = dst.as_ref().parent() {
+            fs::create_dir_all(dir).unwrap();
+        }
+
+        let mut file = File::create(dst).unwrap();
+        io::copy(&mut res, &mut file).unwrap();
+    }
+
+    fn image_path(name: &str) -> PathBuf {
+        let mut path = PathBuf::from("target/doc/safe_vault");
+        path.push(name);
+        path.set_extension("png");
+        path
+    }
+}
 
 // Only generate the diagrams when "generate-diagrams" feature is enabled.
 // TODO: instead of this feature, detect that cargo is run in the "doc" profile.
 #[cfg(feature = "generate-diagrams")]
 fn main() {
     // List all diagram names and URLs to download them from.
-    download_image("personas",
-                   "https://cacoo.com/diagrams/wl6of3FUFriB0FWO-0BD19.png");
-    download_image("immutable-data-put-flow",
-                   "https://cacoo.com/diagrams/SCHrwEhLRB86EGe1-EF9A0.png");
-    download_image("immutable-data-get-flow",
-                   "https://cacoo.com/diagrams/ndcPMKC3WapABSaA-EF9A0.png");
-}
-
-#[cfg(feature = "generate-diagrams")]
-fn download_image<U: IntoUrl>(name: &str, src: U) {
-    download(src, image_path(name))
-}
-
-#[cfg(feature = "generate-diagrams")]
-fn download<U: IntoUrl, P: AsRef<Path>>(src: U, dst: P) {
-    let client = Client::new();
-    let mut res = client.get(src).send().unwrap();
-
-    if let Some(dir) = dst.as_ref().parent() {
-        fs::create_dir_all(dir).unwrap();
-    }
-
-    let mut file = File::create(dst).unwrap();
-    io::copy(&mut res, &mut file).unwrap();
-}
-
-#[cfg(feature = "generate-diagrams")]
-fn image_path(name: &str) -> PathBuf {
-    let mut path = PathBuf::from("target/doc/safe_vault");
-    path.push(name);
-    path.set_extension("png");
-    path
+    generate_diagrams::download_image("personas",
+                                      "https://cacoo.com/diagrams/wl6of3FUFriB0FWO-0BD19.png");
+    generate_diagrams::download_image("immutable-data-put-flow",
+                                      "https://cacoo.com/diagrams/SCHrwEhLRB86EGe1-EF9A0.png");
+    generate_diagrams::download_image("immutable-data-get-flow",
+                                      "https://cacoo.com/diagrams/ndcPMKC3WapABSaA-EF9A0.png");
 }
 
 #[cfg(not(feature = "generate-diagrams"))]


### PR DESCRIPTION
This removes several configuration lines, bringing the build script in line with the equivalent one
in Routing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/467)
<!-- Reviewable:end -->
