### PR TITLE
fix/test: fix an error in cfg block of mock crust test

### DIFF
--- a/src/mock_crust_detail/mod.rs
+++ b/src/mock_crust_detail/mod.rs
@@ -15,7 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-#![cfg(any(test, feature = "use-mock-crust"))]
+#![cfg(feature = "use-mock-crust")]
 
 /// Poll events
 pub mod poll;


### PR DESCRIPTION
This removes a stray `any(test, ...)` in the cfg block of mock_crust_detail/mod.rs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/471)
<!-- Reviewable:end -->
