### PR TITLE
feat/account_info: add support for providing client account information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.8.1"
 [dependencies]
 accumulator = "~0.4.0"
 chunk_store = "~0.4.0"
-clippy = {version = "~0.0.71", optional = true}
+clippy = {version = "~0.0.74", optional = true}
 config_file_handler = "~0.3.0"
 docopt = "~0.6.80"
 itertools = "~0.4.15"

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -193,6 +193,12 @@ impl Vault {
              Request::Delete(Data::Structured(data), msg_id)) => {
                 self.data_manager.handle_delete(src, dst, data, msg_id)
             }
+            // ================== GetAccountInfo ==================
+            (src @ Authority::Client { .. },
+             dst @ Authority::ClientManager(_),
+             Request::GetAccountInfo(msg_id)) => {
+                self.maid_manager.handle_get_account_info(src, dst, msg_id)
+            }
             // ================== Refresh ==================
             (Authority::ClientManager(_),
              Authority::ClientManager(_),


### PR DESCRIPTION
This implements the network-side portion of the new `GetAccountInfo` Client request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/483)
<!-- Reviewable:end -->
