### PR TITLE
chore/deps: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ build = "build.rs"
 description = "This is Pre alpha, and not useful, no code worth looking at."
 documentation = "http://docs.maidsafe.net/safe_vault/latest"
 homepage = "http://maidsafe.net"
-license = "GPL-3.0/MaidSafe.net Commercial License 1.0"
+license = "GPL-3.0"
 name = "safe_vault"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe_vault"
@@ -13,7 +13,7 @@ version = "0.8.1"
 [dependencies]
 accumulator = "~0.4.0"
 chunk_store = "~0.4.0"
-clippy = {version = "~0.0.75", optional = true}
+clippy = {version = "~0.0.76", optional = true}
 config_file_handler = "~0.3.0"
 docopt = "~0.6.80"
 itertools = "~0.4.15"
@@ -21,9 +21,9 @@ kademlia_routing_table = "~0.6.0"
 log = "~0.3.6"
 maidsafe_utilities = "~0.6.0"
 rand = "~0.3.14"
-routing = { git = "https://github.com/maidsafe/routing.git", branch = "async" }
+routing = "~0.22.0"
 rustc-serialize = "~0.3.19"
-safe_network_common = "~0.2.0"
+safe_network_common = "~0.3.0"
 sodiumoxide = "~0.0.10"
 
 [build-dependencies]

--- a/src/personas/data_manager.rs
+++ b/src/personas/data_manager.rs
@@ -38,7 +38,7 @@ const ACCUMULATOR_QUORUM: usize = GROUP_SIZE / 2 + 1;
 /// The timeout for accumulating refresh messages.
 const ACCUMULATOR_TIMEOUT_SECS: u64 = 180;
 /// The timeout for retrieving data chunks from individual peers.
-const GET_FROM_DATA_HOLDER_TIMEOUT_SECS: u64 = 20;
+const GET_FROM_DATA_HOLDER_TIMEOUT_SECS: u64 = 60;
 
 /// Specification of a particular version of a data chunk. For immutable data, the `u64` is always
 /// 0; for structured data, it specifies the version.


### PR DESCRIPTION
Also increase the data manager `Get` timeout to 60 seconds to reduce traffic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_vault/488)
<!-- Reviewable:end -->
