### PR TITLE
refactor/tests: re-enable some mock-crust tests

### DIFF
--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -18,6 +18,8 @@
 //! # Chunk Store
 //! A simple, non-persistent, disk-based key-value store.
 
+mod tests;
+
 use fs2::FileExt;
 use maidsafe_utilities::serialisation::{self, SerialisationError};
 use rustc_serialize::{Decodable, Encodable};
@@ -232,6 +234,3 @@ impl<Key, Value> Drop for ChunkStore<Key, Value> {
         let _ = fs::remove_dir_all(&self.rootdir);
     }
 }
-
-#[cfg(test)]
-mod test;

--- a/src/chunk_store/tests.rs
+++ b/src/chunk_store/tests.rs
@@ -113,10 +113,11 @@ fn successful_put() {
             assert!(chunk_store.used_space() <= chunks.total_size);
         };
 
-        for (index, &(ref data, ref size)) in chunks.data_and_sizes
-            .iter()
-            .enumerate()
-            .rev() {
+        for (index, &(ref data, ref size)) in
+            chunks.data_and_sizes
+                .iter()
+                .enumerate()
+                .rev() {
             put(index, data, size);
         }
     }

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -68,7 +68,7 @@ fn get_file_name() -> Result<OsString, InternalError> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[test]
     fn parse_sample_config_file() {
         use std::path::Path;

--- a/src/mock_crust_detail/test_client.rs
+++ b/src/mock_crust_detail/test_client.rs
@@ -22,8 +22,8 @@ use routing::{self, AppendWrapper, Authority, Data, DataIdentifier, Event, FullI
               PublicId, Response, StructuredData, XorName};
 use routing::client_errors::{GetError, MutationError};
 use routing::mock_crust::{self, Config, Network, ServiceHandle};
-use std::iter;
 use std::collections::BTreeSet;
+use std::iter;
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use super::poll;
 

--- a/src/mock_crust_detail/test_node.rs
+++ b/src/mock_crust_detail/test_node.rs
@@ -23,8 +23,8 @@ use rand::{self, Rng};
 use routing::XorName;
 use routing::mock_crust::{self, Endpoint, Network, ServiceHandle};
 use rustc_serialize::hex::ToHex;
-use std::env;
-use std::fs;
+use std::{env, fs};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use super::poll;
@@ -121,6 +121,12 @@ impl TestNode {
     /// name of vault.
     pub fn name(&self) -> XorName {
         self.vault.name()
+    }
+
+    /// If our group is the closest one to `name`, returns all names in our group *including ours*,
+    /// otherwise returns `None`.
+    pub fn close_group(&self, name: &XorName) -> Option<HashSet<XorName>> {
+        self.vault.close_group(name)
     }
 }
 

--- a/src/personas/maid_manager.rs
+++ b/src/personas/maid_manager.rs
@@ -402,7 +402,7 @@ impl MaidManager {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -25,6 +25,8 @@ use personas::data_manager::IdAndVersion;
 use personas::maid_manager::MaidManager;
 use routing::{Authority, Data, NodeBuilder, Prefix, Request, Response, XorName};
 use rust_sodium;
+#[cfg(feature = "use-mock-crust")]
+use std::collections::HashSet;
 use std::env;
 use std::path::Path;
 use std::rc::Rc;
@@ -162,6 +164,13 @@ impl Vault {
     #[cfg(feature = "use-mock-crust")]
     pub fn name(&self) -> XorName {
         unwrap!(self._routing_node.name())
+    }
+
+    /// If our group is the closest one to `name`, returns all names in our group *including ours*,
+    /// otherwise returns `None`.
+    #[cfg(feature = "use-mock-crust")]
+    pub fn close_group(&self, name: &XorName) -> Option<HashSet<XorName>> {
+        unwrap!(self._routing_node.close_group(*name))
     }
 
     fn process_event(&mut self, event: Event) -> Option<bool> {

--- a/tests/data_manager.rs
+++ b/tests/data_manager.rs
@@ -15,12 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-
 use rand::Rng;
 use rand::distributions::{IndependentSample, Range};
-
 use routing::{AppendWrapper, AppendedData, Authority, Data, DataIdentifier, Event, FullId,
               ImmutableData, MIN_GROUP_SIZE, PrivAppendedData, PubAppendableData, Response,
               StructuredData};
@@ -339,7 +335,6 @@ fn structured_data_operations_with_churn() {
     }
 }
 
-#[ignore]
 #[test]
 fn handle_priv_appendable_normal_flow() {
     let network = Network::new(None);
@@ -369,7 +364,6 @@ fn handle_priv_appendable_normal_flow() {
                client.get(data.identifier(), &mut nodes));
 }
 
-#[ignore]
 #[test]
 fn handle_pub_appendable_normal_flow() {
     let network = Network::new(None);
@@ -462,7 +456,6 @@ fn appendable_data_operations_with_churn() {
     }
 }
 
-#[ignore]
 #[test]
 fn append_oversized_appendable_data() {
     let network = Network::new(None);
@@ -498,7 +491,6 @@ fn append_oversized_appendable_data() {
     }
 }
 
-#[ignore]
 #[test]
 fn post_oversized_appendable_data() {
     let network = Network::new(None);
@@ -531,7 +523,6 @@ fn post_oversized_appendable_data() {
     }
 }
 
-#[ignore]
 #[test]
 fn appendable_data_parallel_append() {
     let network = Network::new(None);
@@ -606,7 +597,6 @@ fn appendable_data_parallel_append() {
     assert!(successes > 2, "Low success rate.");
 }
 
-#[ignore]
 #[test]
 fn appendable_data_parallel_post() {
     let network = Network::new(None);
@@ -691,7 +681,6 @@ fn appendable_data_parallel_post() {
     assert!(failures >= iterations / 2, "Low failure rate.");
 }
 
-#[ignore]
 #[test]
 fn handle_put_get_normal_flow() {
     let network = Network::new(None);
@@ -721,7 +710,6 @@ fn handle_put_get_normal_flow() {
     }
 }
 
-#[ignore]
 #[test]
 fn handle_put_get_error_flow() {
     let network = Network::new(None);
@@ -794,12 +782,9 @@ fn handle_post_error_flow() {
     let _ = client.put_and_verify(Data::Structured(sd.clone()), &mut nodes);
 
     // Posting with incorrect type_tag
-    let mut incorrect_tag_sd = StructuredData::new(200000,
-                                                   *sd.name(),
-                                                   1,
-                                                   sd.get_data().clone(),
-                                                   owner.clone())
-        .expect("Cannot create structured data for test");
+    let mut incorrect_tag_sd =
+        StructuredData::new(200000, *sd.name(), 1, sd.get_data().clone(), owner.clone())
+            .expect("Cannot create structured data for test");
     let _ = incorrect_tag_sd.add_signature(&(pub_key, priv_key.clone()));
     match client.post_response(Data::Structured(incorrect_tag_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::NoSuchData),
@@ -807,12 +792,9 @@ fn handle_post_error_flow() {
     }
 
     // Posting with incorrect version
-    let mut incorrect_version_sd = StructuredData::new(100000,
-                                                       *sd.name(),
-                                                       3,
-                                                       sd.get_data().clone(),
-                                                       owner.clone())
-        .expect("Cannot create structured data for test");
+    let mut incorrect_version_sd =
+        StructuredData::new(100000, *sd.name(), 3, sd.get_data().clone(), owner.clone())
+            .expect("Cannot create structured data for test");
     let _ = incorrect_version_sd.add_signature(&(pub_key, priv_key.clone()));
     match client.post_response(Data::Structured(incorrect_version_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::InvalidSuccessor),
@@ -837,12 +819,9 @@ fn handle_post_error_flow() {
     }
 
     // Posting correctly
-    let mut new_sd = StructuredData::new(100000,
-                                         *sd.name(),
-                                         1,
-                                         sd.get_data().clone(),
-                                         owner.clone())
-        .expect("Cannot create structured data for test");
+    let mut new_sd =
+        StructuredData::new(100000, *sd.name(), 1, sd.get_data().clone(), owner.clone())
+            .expect("Cannot create structured data for test");
     let _ = new_sd.add_signature(&(pub_key, priv_key));
     match client.post_response(Data::Structured(new_sd), &mut nodes) {
         Ok(data_id) => assert_eq!(data_id, sd.identifier()),
@@ -896,11 +875,7 @@ fn handle_delete_error_flow() {
     let _ = client.put_and_verify(Data::Structured(sd.clone()), &mut nodes);
 
     // Deleting with incorrect type_tag
-    let mut incorrect_tag_sd = StructuredData::new(200000,
-                                                   *sd.name(),
-                                                   1,
-                                                   vec![],
-                                                   owner0.clone())
+    let mut incorrect_tag_sd = StructuredData::new(200000, *sd.name(), 1, vec![], owner0.clone())
         .expect("Cannot create structured data for test");
     let _ = incorrect_tag_sd.add_signature(&(pub_key0, priv_key0.clone()));
     match client.delete_response(Data::Structured(incorrect_tag_sd), &mut nodes) {
@@ -909,12 +884,9 @@ fn handle_delete_error_flow() {
     }
 
     // Deleting with incorrect version
-    let mut incorrect_version_sd = StructuredData::new(100000,
-                                                       *sd.name(),
-                                                       3,
-                                                       vec![],
-                                                       owner0.clone())
-        .expect("Cannot create structured data for test");
+    let mut incorrect_version_sd =
+        StructuredData::new(100000, *sd.name(), 3, vec![], owner0.clone())
+            .expect("Cannot create structured data for test");
     let _ = incorrect_version_sd.add_signature(&(pub_key0, priv_key0.clone()));
     match client.delete_response(Data::Structured(incorrect_version_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::InvalidSuccessor),
@@ -922,12 +894,9 @@ fn handle_delete_error_flow() {
     }
 
     // Deleting with incorrect signature
-    let mut incorrect_signed_sd = StructuredData::new(100000,
-                                                      *sd.name(),
-                                                      1,
-                                                      vec![],
-                                                      owner0.clone())
-        .expect("Cannot create structured data for test");
+    let mut incorrect_signed_sd =
+        StructuredData::new(100000, *sd.name(), 1, vec![], owner0.clone())
+            .expect("Cannot create structured data for test");
     let _ = incorrect_signed_sd.add_signature(&(pub_key0, priv_key1.clone()));
     match client.delete_response(Data::Structured(incorrect_signed_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::InvalidSuccessor),
@@ -935,12 +904,9 @@ fn handle_delete_error_flow() {
     }
 
     // Deleting
-    let mut new_sd = StructuredData::new(100000,
-                                         *sd.name(),
-                                         1,
-                                         sd.get_data().clone(),
-                                         owner0.clone())
-        .expect("Cannot create structured data for test");
+    let mut new_sd =
+        StructuredData::new(100000, *sd.name(), 1, sd.get_data().clone(), owner0.clone())
+            .expect("Cannot create structured data for test");
     let _ = new_sd.add_signature(&(pub_key0, priv_key0.clone()));
     let deleted_data = Data::Structured(new_sd);
     match client.delete_response(deleted_data.clone(), &mut nodes) {
@@ -962,12 +928,9 @@ fn handle_delete_error_flow() {
     }
 
     // Deleted data cannot be posted
-    let mut post_sd = StructuredData::new(100000,
-                                          *sd.name(),
-                                          2,
-                                          sd.get_data().clone(),
-                                          owner0.clone())
-        .expect("Cannot create structured data for test");
+    let mut post_sd =
+        StructuredData::new(100000, *sd.name(), 2, sd.get_data().clone(), owner0.clone())
+            .expect("Cannot create structured data for test");
     let _ = post_sd.add_signature(&(pub_key0, priv_key0.clone()));
     match client.post_response(Data::Structured(post_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::InvalidOperation),
@@ -975,12 +938,9 @@ fn handle_delete_error_flow() {
     }
 
     // Deleted data cannot be put with version 0
-    let mut incorrect_reput_sd = StructuredData::new(100000,
-                                                     *sd.name(),
-                                                     0,
-                                                     sd.get_data().clone(),
-                                                     owner0.clone())
-        .expect("Cannot create structured data for test");
+    let mut incorrect_reput_sd =
+        StructuredData::new(100000, *sd.name(), 0, sd.get_data().clone(), owner0.clone())
+            .expect("Cannot create structured data for test");
     let _ = incorrect_reput_sd.add_signature(&(pub_key0, priv_key0.clone()));
     match client.put_and_verify(Data::Structured(incorrect_reput_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::DataExists),
@@ -989,12 +949,9 @@ fn handle_delete_error_flow() {
 
     // Deleted data can be put with version + 1, even by a different owner.
     let owner1 = iter::once(pub_key1).collect::<BTreeSet<_>>();
-    let mut reput_sd = StructuredData::new(100000,
-                                           *sd.name(),
-                                           2,
-                                           sd.get_data().clone(),
-                                           owner1.clone())
-        .expect("Cannot create structured data for test");
+    let mut reput_sd =
+        StructuredData::new(100000, *sd.name(), 2, sd.get_data().clone(), owner1.clone())
+            .expect("Cannot create structured data for test");
     let _ = reput_sd.add_signature(&(pub_key1, priv_key1.clone()));
     let reput_data = Data::Structured(reput_sd);
     let _ = client.put_and_verify(reput_data.clone(), &mut nodes);
@@ -1015,7 +972,7 @@ fn caching_with_data_not_close_to_proxy_node() {
     client.create_account(&mut nodes);
     let mut rng = network.new_rng();
 
-    let sent_data = gen_random_immutable_data_not_close_to(&nodes[0], &mut rng);
+    let sent_data = generate_cache_data(&nodes[0], &mut rng, false);
     let _ = client.put_and_verify(sent_data.clone(), &mut nodes);
 
     // The first response is not yet cached, so it comes from a NAE manager authority.
@@ -1043,7 +1000,6 @@ fn caching_with_data_not_close_to_proxy_node() {
     }
 }
 
-#[ignore]
 #[test]
 fn caching_with_data_close_to_proxy_node() {
     let network = Network::new(None);
@@ -1057,7 +1013,7 @@ fn caching_with_data_close_to_proxy_node() {
     client.create_account(&mut nodes);
     let mut rng = network.new_rng();
 
-    let sent_data = gen_random_immutable_data_close_to(&nodes[0], &mut rng);
+    let sent_data = generate_cache_data(&nodes[0], &mut rng, true);
     let _ = client.put_and_verify(sent_data.clone(), &mut nodes);
 
     // Send two requests and verify the response is not cached in any of them
@@ -1084,22 +1040,12 @@ fn caching_with_data_close_to_proxy_node() {
     }
 }
 
-fn gen_random_immutable_data_close_to<R: Rng>(_node: &TestNode, _rng: &mut R) -> Data {
-    unimplemented!();
-    // loop {
-    //     let data = Data::Immutable(test_utils::random_immutable_data(10, rng));
-    //     if node.routing_table().is_close(&data.name(), MIN_GROUP_SIZE) {
-    //         return data;
-    //     }
-    // }
-}
-
-fn gen_random_immutable_data_not_close_to<R: Rng>(_node: &TestNode, _rng: &mut R) -> Data {
-    unimplemented!();
-    // loop {
-    //     let data = Data::Immutable(test_utils::random_immutable_data(10, rng));
-    //     if !node.routing_table().is_close(&data.name(), MIN_GROUP_SIZE) {
-    //         return data;
-    //     }
-    // }
+fn generate_cache_data<R: Rng>(node: &TestNode, rng: &mut R, close_to_node: bool) -> Data {
+    loop {
+        let data = Data::Immutable(test_utils::random_immutable_data(10, rng));
+        let is_close_to_node = node.close_group(data.name()).is_some();
+        if (close_to_node && is_close_to_node) || (!close_to_node && !is_close_to_node) {
+            return data;
+        }
+    }
 }

--- a/tests/maid_manager.rs
+++ b/tests/maid_manager.rs
@@ -15,9 +15,6 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-
 use itertools::Itertools;
 use rand::Rng;
 use rand::distributions::{IndependentSample, Range};
@@ -33,7 +30,6 @@ use std::collections::BTreeSet;
 
 const TEST_NET_SIZE: usize = 20;
 
-#[ignore]
 #[test]
 fn handle_put_without_account() {
     let network = Network::new(None);
@@ -59,7 +55,6 @@ fn handle_put_without_account() {
             node_count);
 }
 
-#[ignore]
 #[test]
 fn put_oversized_data() {
     let network = Network::new(None);
@@ -138,8 +133,8 @@ fn handle_put_with_account() {
     let count = nodes.iter()
         .filter(|node| node.get_maid_manager_put_count(client.name()).is_some())
         .count();
-    assert!(MIN_GROUP_SIZE == count,
-            "client account {} found on {} nodes",
+    assert!(MIN_GROUP_SIZE <= count,
+            "{} instances of client account found on {} nodes",
             count,
             node_count);
     let mut stored_immutable = Vec::new();
@@ -151,7 +146,6 @@ fn handle_put_with_account() {
                (expected_data_stored, expected_space_available));
 }
 
-#[ignore]
 #[test]
 fn create_account_twice() {
     let default_account_size = 100;
@@ -211,7 +205,6 @@ fn create_account_twice() {
     assert_eq!(client1.get_account_info_response(&mut nodes), acct_err);
 }
 
-#[ignore]
 #[test]
 #[should_panic] // TODO Look at using std::panic::catch_unwind (1.9)
 fn invalid_put_for_previously_created_account() {
@@ -226,7 +219,6 @@ fn invalid_put_for_previously_created_account() {
     client.create_account(&mut nodes);
 }
 
-#[ignore]
 #[test]
 fn storing_till_client_account_full() {
     // This needs to be kept in sync with maid_manager.rs
@@ -260,7 +252,7 @@ fn storing_till_client_account_full() {
 
 #[ignore]
 #[test]
-fn maid_manager_account_adding_with_churn() {
+fn account_adding_with_churn() {
     let network = Network::new(None);
     let node_count = 15;
     let mut nodes = test_node::create_nodes(&network, node_count, None, false);
@@ -317,7 +309,7 @@ fn maid_manager_account_adding_with_churn() {
 
 #[ignore]
 #[test]
-fn maid_manager_account_decrease_with_churn() {
+fn account_decrease_with_churn() {
     let network = Network::new(None);
     let node_count = 15;
     let mut nodes = test_node::create_nodes(&network, node_count, None, false);

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -15,78 +15,73 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
+use rand::Rng;
+use rand::distributions::{IndependentSample, Range};
+use routing::{Data, ImmutableData};
+use routing::mock_crust::{self, Network};
+use safe_vault::Config;
+use safe_vault::mock_crust_detail::{poll, test_node};
+use safe_vault::mock_crust_detail::test_client::TestClient;
+use safe_vault::test_utils;
 
-mod test {
-    use rand::Rng;
-    use rand::distributions::{IndependentSample, Range};
-    use routing::{Data, ImmutableData};
-    use routing::mock_crust::{self, Network};
-    use safe_vault::Config;
-    use safe_vault::mock_crust_detail::{poll, test_node};
-    use safe_vault::mock_crust_detail::test_client::TestClient;
-    use safe_vault::test_utils;
+#[ignore]
+#[test]
+fn fill_network() {
+    let network = Network::new(None);
+    let config = Config {
+        wallet_address: None,
+        max_capacity: Some(2000),
+        chunk_store_root: None,
+    };
+    // Use 8 nodes to avoid the case where four target nodes are full: In that case neither the
+    // PutSuccess nor the PutFailure accumulates and client.put_and_verify() would hang.
+    let mut nodes = test_node::create_nodes(&network, 8, Some(config), true);
+    let crust_config = mock_crust::Config::with_contacts(&[nodes[0].endpoint()]);
+    let mut client = TestClient::new(&network, Some(crust_config));
+    let full_id = client.full_id().clone();
+    let mut rng = network.new_rng();
 
-    #[ignore]
-    #[test]
-    fn fill_network() {
-        let network = Network::new(None);
-        let config = Config {
-            wallet_address: None,
-            max_capacity: Some(2000),
-            chunk_store_root: None,
-        };
-        // Use 8 nodes to avoid the case where four target nodes are full: In that case neither the
-        // PutSuccess nor the PutFailure accumulates and client.put_and_verify() would hang.
-        let mut nodes = test_node::create_nodes(&network, 8, Some(config), true);
-        let crust_config = mock_crust::Config::with_contacts(&[nodes[0].endpoint()]);
-        let mut client = TestClient::new(&network, Some(crust_config));
-        let full_id = client.full_id().clone();
-        let mut rng = network.new_rng();
+    client.ensure_connected(&mut nodes);
+    client.create_account(&mut nodes);
 
-        client.ensure_connected(&mut nodes);
-        client.create_account(&mut nodes);
-
-        loop {
-            let data = if rng.gen() {
-                let content = rng.gen_iter().take(100).collect();
-                Data::Immutable(ImmutableData::new(content))
-            } else {
-                Data::Structured(test_utils::random_structured_data(100000, &full_id, &mut rng))
-            };
-            let data_id = data.identifier();
-            match client.put_and_verify(data, &mut nodes) {
-                Ok(()) => trace!("Stored chunk {:?}", data_id),
-                Err(None) => trace!("Got no response storing chunk {:?}", data_id),
-                Err(Some(response)) => {
-                    trace!("Failed storing chunk {:?}, response: {:?}",
-                           data_id,
-                           response);
-                    break;
-                }
-            }
-        }
-        for _ in 0..10 {
-            let index = Range::new(1, nodes.len()).ind_sample(&mut rng);
-            trace!("Adding node with bootstrap node {}.", index);
-            test_node::add_node(&network, &mut nodes, index, true);
-            let _ = poll::poll_and_resend_unacknowledged(&mut nodes, &mut client);
+    loop {
+        let data = if rng.gen() {
             let content = rng.gen_iter().take(100).collect();
-            let data = Data::Immutable(ImmutableData::new(content));
-            let data_id = data.identifier();
-            match client.put_and_verify(data, &mut nodes) {
-                Ok(()) => {
-                    trace!("Stored chunk {:?}", data_id);
-                    return;
-                }
-                Err(opt_response) => {
-                    trace!("Failed storing chunk {:?}, response: {:?}",
-                           data_id,
-                           opt_response);
-                }
+            Data::Immutable(ImmutableData::new(content))
+        } else {
+            Data::Structured(test_utils::random_structured_data(100000, &full_id, &mut rng))
+        };
+        let data_id = data.identifier();
+        match client.put_and_verify(data, &mut nodes) {
+            Ok(()) => trace!("Stored chunk {:?}", data_id),
+            Err(None) => trace!("Got no response storing chunk {:?}", data_id),
+            Err(Some(response)) => {
+                trace!("Failed storing chunk {:?}, response: {:?}",
+                       data_id,
+                       response);
+                break;
             }
         }
-        panic!("Failed to put again after adding nodes.");
     }
+    for _ in 0..10 {
+        let index = Range::new(1, nodes.len()).ind_sample(&mut rng);
+        trace!("Adding node with bootstrap node {}.", index);
+        test_node::add_node(&network, &mut nodes, index, true);
+        let _ = poll::poll_and_resend_unacknowledged(&mut nodes, &mut client);
+        let content = rng.gen_iter().take(100).collect();
+        let data = Data::Immutable(ImmutableData::new(content));
+        let data_id = data.identifier();
+        match client.put_and_verify(data, &mut nodes) {
+            Ok(()) => {
+                trace!("Stored chunk {:?}", data_id);
+                return;
+            }
+            Err(opt_response) => {
+                trace!("Failed storing chunk {:?}, response: {:?}",
+                       data_id,
+                       opt_response);
+            }
+        }
+    }
+    panic!("Failed to put again after adding nodes.");
 }


### PR DESCRIPTION
Also renames any "test" mods to "tests".

Although the diff for [tests/network.rs](https://github.com/maidsafe/safe_vault/compare/dev...Fraser999:MAID-1679?expand=1#diff-fc594075c6df4aa13e74822d88e34a9e) is large, the only change there was to remove the `mod test` scope and run rustfmt.