### PR TITLE
MAID-2000: chore/all: cleanup/improve CI scripts and README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,10 +102,7 @@ before_script:
   - (which cargo-install-update && cargo install-update cargo-update) || cargo install cargo-update
   - (which cargo-prune && cargo install-update cargo-prune) || cargo install cargo-prune
   - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
-      rustfmt_vers=0.7.1;
-      if ! cargo fmt -- --version | grep -q $rustfmt_vers; then
-        cargo install rustfmt --vers==$rustfmt_vers --force;
-      fi
+      (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt;
     elif [ -z "${TARGET}" ] && [ "${TRAVIS_OS_NAME}" = linux ]; then
       clippy_vers=0.0.104;
       if ! cargo clippy --version | grep -q $clippy_vers; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 build = "build.rs"
-description = "This is Pre alpha, and not useful, no code worth looking at."
-documentation = "http://docs.maidsafe.net/safe_vault/latest"
-homepage = "http://maidsafe.net"
+description = "Implementation of the 'Vault' node for the SAFE Network."
+documentation = "https://docs.rs/safe_vault"
+homepage = "https://maidsafe.net"
 license = "GPL-3.0"
 name = "safe_vault"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 **Maintainer:** Andreas Fackler (andreas.fackler@maidsafe.net)
 
-|Crate|Linux/OS X|ARM (Linux)|Windows|Coverage|Issues|
-|:---:|:--------:|:---------:|:-----:|:------:|:----:|
-|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Build Status](https://travis-ci.org/maidsafe/safe_vault.svg?branch=master)](https://travis-ci.org/maidsafe/safe_vault)|[![Build Status](http://ci.maidsafe.net:8080/buildStatus/icon?job=safe_vault_arm_status_badge)](http://ci.maidsafe.net:8080/job/safe_vault_arm_status_badge/)|[![Build status](https://ci.appveyor.com/api/projects/status/ohu678c6ufw8b2bn/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-vault/branch/master)|[![Coverage Status](https://coveralls.io/repos/maidsafe/safe_vault/badge.svg)](https://coveralls.io/r/maidsafe/safe_vault)|[![Stories in Ready](https://badge.waffle.io/maidsafe/safe_vault.png?label=ready&title=Ready)](https://waffle.io/maidsafe/safe_vault)|
+|Crate|Documentation|Linux/OS X|Windows|Issues|
+|:---:|:-----------:|:--------:|:-----:|:----:|
+|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![Build Status](https://travis-ci.org/maidsafe/safe_vault.svg?branch=master)](https://travis-ci.org/maidsafe/safe_vault)|[![Build status](https://ci.appveyor.com/api/projects/status/ohu678c6ufw8b2bn/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-vault/branch/master)|[![Stories in Ready](https://badge.waffle.io/maidsafe/safe_vault.png?label=ready&title=Ready)](https://waffle.io/maidsafe/safe_vault)|
 
-| [API Docs - master branch](http://docs.maidsafe.net/safe_vault/master) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
-|:------:|:-------:|:-------:|:-------:|
+| [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+|:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
 
 ## Overview
 
@@ -25,6 +25,5 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
-work by you, as defined in the MaidSafe Contributor Agreement, version 1.1 ([CONTRIBUTOR]
-(CONTRIBUTOR)), shall be dual licensed as above, and you agree to be bound by the terms of the
-MaidSafe Contributor Agreement, version 1.1.
+work by you, as defined in the MaidSafe Contributor Agreement ([CONTRIBUTOR](CONTRIBUTOR)), shall be
+dual licensed as above, and you agree to be bound by the terms of the MaidSafe Contributor Agreement.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,14 @@ environment:
     RUST_BACKTRACE: 1
   matrix:
     - RUST_VERSION: stable
+
 branches:
   only:
     - dev
     - master
 
-clone_depth: 50
+clone_depth: 1
+
 skip_tags: true
 
 cache:
@@ -21,9 +23,7 @@ cache:
 install:
   - ps: |
         $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
-        Start-FileDownload "$url/Install%20Rustup.ps1" -FileName "Install Rustup.ps1"
-        Start-FileDownload "$url/Build.ps1" -FileName "Build.ps1"
-        Start-FileDownload "$url/Run%20Tests.ps1" -FileName "Run Tests.ps1"
+        cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
         . ".\Install Rustup.ps1"
 
         $commit_message = "$env:APPVEYOR_REPO_COMMIT_MESSAGE $env:APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED"
@@ -41,10 +41,10 @@ configuration:
   - Release
 
 build_script:
-  - ps: . ".\Build.ps1"
+  - cargo rustc --verbose --release --profile test --lib -- -Zno-trans
 
 test_script:
-  - ps: . ".\Run Tests.ps1"
+  - cargo test --verbose --release
 
 before_deploy:
   - ps: . ".\ci\appveyor\before_deploy.ps1"

--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/installer/common/invoke_fpm.sh
+++ b/installer/common/invoke_fpm.sh
@@ -387,7 +387,7 @@ function create_package {
     --directories $ConfigFileDir \
     --maintainer "MaidSafe QA <qa@maidsafe.net>" \
     --description "$Description" \
-    --url "http://maidsafe.net" \
+    --url "https://maidsafe.net" \
     $BeforeInstallCommand \
     $AfterInstallCommand \
     $BeforeRemoveCommand \

--- a/installer/windows/safe_vault_32_and_64_bit.aip
+++ b/installer/windows/safe_vault_32_and_64_bit.aip
@@ -16,7 +16,7 @@
     <ROW Property="ARPNOMODIFY" MultiBuildValue="DefaultBuild:1#x64_1:1"/>
     <ROW Property="ARPNOREPAIR" Value="1"/>
     <ROW Property="ARPPRODUCTICON" Value="maidsafe_logo.exe" Type="8"/>
-    <ROW Property="ARPURLINFOABOUT" Value="http://maidsafe.net"/>
+    <ROW Property="ARPURLINFOABOUT" Value="https://maidsafe.net"/>
     <ROW Property="AiStyleConditions" Value="|DefaultUIFont;AI_ThemeStyle=&quot;default&quot;:DlgFont8;AI_ThemeStyle=&quot;metrored&quot;:DefaultTextWhite;AI_ThemeStyle=&quot;metrowhite&quot;:DefaultTextBlack;|HyperlinkFont;AI_ThemeStyle=&quot;default&quot;:{\MetroLink};AI_ThemeStyle=&quot;metrored&quot;:{\MetroLinkLightRed};AI_ThemeStyle=&quot;metrowhite&quot;:{\MetroLink};|MetroButtonText;AI_ThemeStyle=&quot;default&quot;:{\ImageButton};AI_ThemeStyle=&quot;metrored&quot;:{\MetroButtonTextWhite};AI_ThemeStyle=&quot;metrowhite&quot;:{\MetroButtonTextBlack};|InputCtrlFont;AI_ThemeStyle=&quot;default&quot;:{\InputCtrlFontGray};AI_ThemeStyle=&quot;metrored&quot;:{\InputCtrlFont};AI_ThemeStyle=&quot;metrowhite&quot;:{\InputCtrlFontBlack};|BrandingStyle;AI_ThemeStyle=&quot;default&quot;:{\BrandingStyleGray};AI_ThemeStyle=&quot;metrored&quot;:{\BrandingStyle};AI_ThemeStyle=&quot;metrowhite&quot;:{\BrandingStyleLightGray};|SubTitleStyle;AI_ThemeStyle=&quot;default&quot;:{\SubTitle};AI_ThemeStyle=&quot;metrored&quot;:{\SubTitleWhite};AI_ThemeStyle=&quot;metrowhite&quot;:{\SubTitleBlack};|SubnoteFontStyle;AI_ThemeStyle=&quot;default&quot;:{\SubnoteFont};AI_ThemeStyle=&quot;metrored&quot;:{\SubnoteFontWhite};AI_ThemeStyle=&quot;metrowhite&quot;:{\SubnoteFontGray};|ProductNameForSplash;AI_ThemeStyle=&quot;default&quot;:{\ProductNameForSplash};AI_ThemeStyle=&quot;metrored&quot;:{\ProductNameForSplash};AI_ThemeStyle=&quot;metrowhite&quot;:{\ProductNameForSplashDark}|ManufacturerFont;AI_ThemeStyle=&quot;default&quot;:{\Manufacturer};AI_ThemeStyle=&quot;metrored&quot;:{\Manufacturer};AI_ThemeStyle=&quot;metrowhite&quot;:{\ManufacturerGreen};|MetroInstallButtonFont;AI_ThemeStyle=&quot;default&quot;:{\MetroInstallButton};AI_ThemeStyle=&quot;metrored&quot;:{\MetroInstallButton};AI_ThemeStyle=&quot;metrowhite&quot;:{\MetroInstallButtonGreen};" MsiKey="AiStyleConditions"/>
     <ROW Property="AppLogoIcon" Value="applogoicon" MultiBuildValue="DefaultBuild:maidsafe_triangle.png#x64_1:maidsafe_triangle.png" Type="1" MsiKey="AppLogoIcon"/>
     <ROW Property="CTRLS" Value="2"/>
@@ -74,7 +74,7 @@
     <ROW Path="&lt;AI_DICTS&gt;ui_en.ail"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.DigCertStoreComponent">
-    <ROW DigitalCertificate="..\..\..\Enter path to certificate.p12" TimeStampUrl="http://timestamp.comodoca.com/authenticode" SignerDescription="[|ProductName]" DescriptionUrl="http://maidsafe.net" SignOptions="7" SignTool="0" UseSha256="1"/>
+    <ROW DigitalCertificate="..\..\..\Enter path to certificate.p12" TimeStampUrl="http://timestamp.comodoca.com/authenticode" SignerDescription="[|ProductName]" DescriptionUrl="https://maidsafe.net" SignOptions="7" SignTool="0" UseSha256="1"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.FragmentComponent">
     <ROW Fragment="CommonUI.aip" Path="&lt;AI_FRAGS&gt;CommonUI.aip"/>

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,8 +20,8 @@
 
 #![doc(html_logo_url =
            "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
-       html_favicon_url = "http://maidsafe.net/img/favicon.ico",
-       html_root_url = "http://maidsafe.github.io/safe_vault")]
+       html_favicon_url = "https://maidsafe.net/img/favicon.ico",
+       html_root_url = "https://docs.rs/safe_vault")]
 
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
@@ -76,9 +76,8 @@ pub fn main() {
     // TODO - remove the following line once maidsafe_utilities is updated to use log4rs v4.
     let _ = fs::remove_file("Node.log");
 
-    let args: Args = Docopt::new(USAGE)
-        .and_then(|docopt| docopt.decode())
-        .unwrap_or_else(|error| error.exit());
+    let args: Args =
+        Docopt::new(USAGE).and_then(|docopt| docopt.decode()).unwrap_or_else(|error| error.exit());
 
     let name = config_file_handler::exe_file_stem().unwrap_or_else(|_| OsString::new());
     let name_and_version = format!("{} v{}", name.to_string_lossy(), env!("CARGO_PKG_VERSION"));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -88,12 +88,12 @@ impl<Key, Value> ChunkStore<Key, Value>
     pub fn new(root: PathBuf, max_space: u64) -> Result<ChunkStore<Key, Value>, Error> {
         let lock_file = Self::lock_and_clear_dir(&root)?;
         Ok(ChunkStore {
-            rootdir: root,
-            lock_file: Some(lock_file),
-            max_space: max_space,
-            used_space: 0,
-            phantom: PhantomData,
-        })
+               rootdir: root,
+               lock_file: Some(lock_file),
+               max_space: max_space,
+               used_space: 0,
+               phantom: PhantomData,
+           })
     }
 
     /// Stores a new data chunk under `key`.
@@ -227,7 +227,10 @@ impl<Key, Value> ChunkStore<Key, Value>
 
 impl<Key, Value> Drop for ChunkStore<Key, Value> {
     fn drop(&mut self) {
-        let _ = self.lock_file.take().iter().map(File::unlock);
+        let _ = self.lock_file
+            .take()
+            .iter()
+            .map(File::unlock);
         let _ = fs::remove_dir_all(&self.rootdir);
     }
 }

--- a/src/chunk_store/test.rs
+++ b/src/chunk_store/test.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -112,7 +112,11 @@ fn successful_put() {
             assert!(chunk_store.used_space() <= chunks.total_size);
         };
 
-        for (index, &(ref data, ref size)) in chunks.data_and_sizes.iter().enumerate().rev() {
+        for (index, &(ref data, ref size)) in
+            chunks.data_and_sizes
+                .iter()
+                .enumerate()
+                .rev() {
             put(index, data, size);
         }
     }

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.1.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -192,8 +192,8 @@
 
 #![doc(html_logo_url =
            "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
-       html_favicon_url = "http://maidsafe.net/img/favicon.ico",
-       html_root_url = "http://maidsafe.github.io/safe_vault")]
+       html_favicon_url = "https://maidsafe.net/img/favicon.ico",
+       html_root_url = "https://docs.rs/safe_vault")]
 
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md

--- a/src/mock_crust_detail/mod.rs
+++ b/src/mock_crust_detail/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,11 +33,11 @@ use std::collections::{HashMap, HashSet};
 pub fn check_deleted_data(deleted_data: &[Data], nodes: &[TestNode]) {
     let deleted_data_ids: HashSet<_> = deleted_data.iter().map(Data::identifier).collect();
     let mut data_count = HashMap::new();
-    nodes.iter()
-        .flat_map(TestNode::get_stored_names)
-        .foreach(|data_idv| if deleted_data_ids.contains(&data_idv.0) {
-            *data_count.entry(data_idv).or_insert(0) += 1;
-        });
+    nodes.iter().flat_map(TestNode::get_stored_names).foreach(|data_idv| if
+        deleted_data_ids.contains(&data_idv.0) {
+                                                                  *data_count.entry(data_idv)
+                                                                       .or_insert(0) += 1;
+                                                              });
     for (data_id, count) in data_count {
         assert!(count < 5,
                 "Found deleted data: {:?}. count: {}",
@@ -67,9 +67,10 @@ pub fn check_data(all_data: Vec<Data>, nodes: &[TestNode]) {
             .into_iter()
             .sorted_by(|left, right| data_id.name().cmp_distance(left, right));
 
-        let mut expected_data_holders = nodes.iter()
-            .map(TestNode::name)
-            .sorted_by(|left, right| data_id.name().cmp_distance(left, right));
+        let mut expected_data_holders =
+            nodes.iter().map(TestNode::name).sorted_by(|left, right| {
+                                                           data_id.name().cmp_distance(left, right)
+                                                       });
 
         expected_data_holders.truncate(GROUP_SIZE);
 

--- a/src/mock_crust_detail/poll.rs
+++ b/src/mock_crust_detail/poll.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/mock_crust_detail/test_client.rs
+++ b/src/mock_crust_detail/test_client.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -153,8 +153,7 @@ impl TestClient {
         let dst = Authority::NaeManager(*request.name());
         let request_message_id = MessageId::new();
         self.flush();
-        unwrap!(self.routing_client
-            .send_get_request(dst.clone(), request, request_message_id));
+        unwrap!(self.routing_client.send_get_request(dst.clone(), request, request_message_id));
         let events_count = poll::nodes_and_client(nodes, self);
         trace!("totally {} events got processed during the get_response",
                events_count);
@@ -191,8 +190,7 @@ impl TestClient {
                          -> Result<DataIdentifier, Option<MutationError>> {
         let dst = Authority::NaeManager(*data.name());
         let request_message_id = MessageId::new();
-        unwrap!(self.routing_client
-            .send_post_request(dst.clone(), data, request_message_id));
+        unwrap!(self.routing_client.send_post_request(dst.clone(), data, request_message_id));
         let events_count = poll::nodes_and_client(nodes, self);
         trace!("totally {} events got processed during the post_response",
                events_count);
@@ -229,8 +227,7 @@ impl TestClient {
                            -> Result<DataIdentifier, Option<MutationError>> {
         let dst = Authority::NaeManager(*data.name());
         let request_message_id = MessageId::new();
-        unwrap!(self.routing_client
-            .send_delete_request(dst.clone(), data, request_message_id));
+        unwrap!(self.routing_client.send_delete_request(dst.clone(), data, request_message_id));
         let events_count = poll::nodes_and_client(nodes, self);
         trace!("totally {} events got processed during the delete_response",
                events_count);
@@ -267,8 +264,7 @@ impl TestClient {
         let request_message_id = MessageId::new();
         self.flush();
         let dst = Authority::ClientManager(*self.public_id.name());
-        unwrap!(self.routing_client
-            .send_get_account_info_request(dst, request_message_id));
+        unwrap!(self.routing_client.send_get_account_info_request(dst, request_message_id));
         let events_count = poll::nodes_and_client(nodes, self);
         trace!("totally {} events got processed during the get_account_info_response",
                events_count);

--- a/src/mock_crust_detail/test_node.rs
+++ b/src/mock_crust_detail/test_node.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -45,10 +45,10 @@ impl TestNode {
         let handle = network.new_service_handle(crust_config, None);
         let temp_root = env::temp_dir();
         let chunk_store_root = temp_root.join(rand::thread_rng()
-            .gen_iter()
-            .take(8)
-            .collect::<Vec<u8>>()
-            .to_hex());
+                                                  .gen_iter()
+                                                  .take(8)
+                                                  .collect::<Vec<u8>>()
+                                                  .to_hex());
         let vault_config = match config {
             Some(config) => {
                 Config {

--- a/src/personas/maid_manager.rs
+++ b/src/personas/maid_manager.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -14,7 +14,6 @@
 //
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
-
 
 use GROUP_SIZE;
 use error::InternalError;
@@ -162,7 +161,7 @@ impl MaidManager {
                                   MessageId::zero());
                 // Send failure response back to client
                 let error = match (data_id,
-                                   serialisation::deserialise(external_error_indicator)?) {
+                       serialisation::deserialise(external_error_indicator)?) {
                     (DataIdentifier::Structured(_, TYPE_TAG_SESSION_PACKET),
                      MutationError::DataExists) => {
                         // We wouldn't have forwarded two `Put` requests for the same account, so
@@ -171,8 +170,10 @@ impl MaidManager {
                         let refresh = Refresh::Delete(client_name);
                         if let Ok(serialised_refresh) = serialisation::serialise(&refresh) {
                             trace!("MM sending delete refresh for account {}", src.name());
-                            let _ = routing_node
-                                .send_refresh_request(dst, dst, serialised_refresh, msg_id);
+                            let _ = routing_node.send_refresh_request(dst,
+                                                                      dst,
+                                                                      serialised_refresh,
+                                                                      msg_id);
                         }
                         MutationError::AccountExists
                     }
@@ -199,8 +200,10 @@ impl MaidManager {
                                                                msg_id);
         } else {
             let external_error_indicator = serialisation::serialise(&GetError::NoSuchAccount)?;
-            let _ = routing_node
-                .send_get_account_info_failure(dst, src, external_error_indicator, msg_id);
+            let _ = routing_node.send_get_account_info_failure(dst,
+                                                               src,
+                                                               external_error_indicator,
+                                                               msg_id);
         }
         Ok(())
     }
@@ -242,7 +245,11 @@ impl MaidManager {
                              routing_table: &RoutingTable<XorName>) {
         // Remove all accounts which we are no longer responsible for.
         let not_close = |name: &&XorName| !routing_table.is_closest(*name, GROUP_SIZE);
-        let accounts_to_delete = self.accounts.keys().filter(not_close).cloned().collect_vec();
+        let accounts_to_delete = self.accounts
+            .keys()
+            .filter(not_close)
+            .cloned()
+            .collect_vec();
         // Remove all requests from the cache that we are no longer responsible for.
         let msg_ids_to_delete = self.request_cache
             .iter()
@@ -357,10 +364,10 @@ impl MaidManager {
             .get_mut(&client_name)
             .ok_or(MutationError::NoSuchAccount)
             .and_then(|account| {
-                let result = account.add_entry();
-                trace!("Client account {:?}: {:?}", client_name, account);
-                result
-            });
+                          let result = account.add_entry();
+                          trace!("Client account {:?}: {:?}", client_name, account);
+                          result
+                      });
         if let Err(error) = result {
             trace!("MM responds put_failure of data {}, due to error {:?}",
                    data.name(),

--- a/src/personas/mod.rs
+++ b/src/personas/mod.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -59,7 +59,7 @@ pub fn random_structured_data_with_size<R: Rng>(type_tag: u64,
                                      0,
                                      rng.gen_iter().take(size).collect(),
                                      owner)
-        .expect("Cannot create structured data for test");
+            .expect("Cannot create structured data for test");
     let _ = sd.add_signature(&(owner_pubkey, full_id.signing_private_key().clone()));
     sd
 }
@@ -81,7 +81,7 @@ pub fn random_pub_appendable_data_with_size<R: Rng>(full_id: &FullId,
                                         owner,
                                         BTreeSet::new(),
                                         Filter::black_list(None))
-        .expect("Cannot create public appendable data for test");
+            .expect("Cannot create public appendable data for test");
 
     for _ in 0..size / 128 {
         let pointer = DataIdentifier::Structured(rng.gen(), 12345);
@@ -106,7 +106,7 @@ pub fn pub_appendable_data_version_up<R: Rng>(full_id: &FullId,
                                             owner,
                                             BTreeSet::new(),
                                             Filter::black_list(None))
-        .expect("Cannot create public appendable data for test");
+            .expect("Cannot create public appendable data for test");
     for data in old_ad.get_data() {
         new_ad.append(data.clone());
     }
@@ -140,7 +140,7 @@ pub fn random_priv_appendable_data_with_size<R: Rng>(full_id: &FullId,
                                          BTreeSet::new(),
                                          Filter::black_list(None),
                                          encrypt_key)
-        .expect("Cannot create private appendable data for test");
+            .expect("Cannot create private appendable data for test");
 
     for _ in 0..size / 128 {
         let pointer = DataIdentifier::Structured(rng.gen(), 12345);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -14,7 +14,6 @@
 //
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
-
 
 use routing::{Authority, XorName};
 use rust_sodium::crypto::hash::sha256;

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -14,7 +14,6 @@
 //
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
-
 
 use GROUP_SIZE;
 use cache::Cache;
@@ -95,12 +94,11 @@ impl Vault {
         }?;
 
         Ok(Vault {
-            maid_manager: MaidManager::new(),
-            data_manager: DataManager::new(chunk_store_root,
-                                           config.max_capacity
-                                               .unwrap_or(DEFAULT_MAX_CAPACITY))?,
-            routing_node: routing_node,
-        })
+               maid_manager: MaidManager::new(),
+               data_manager: DataManager::new(chunk_store_root,
+                                              config.max_capacity.unwrap_or(DEFAULT_MAX_CAPACITY))?,
+               routing_node: routing_node,
+           })
 
     }
 
@@ -169,27 +167,27 @@ impl Vault {
         let mut ret = None;
 
         if let Err(error) = match event {
-            Event::Request { request, src, dst } => self.on_request(request, src, dst),
-            Event::Response { response, src, dst } => self.on_response(response, src, dst),
-            Event::NodeAdded(node_added, routing_table) => {
-                self.on_node_added(node_added, routing_table)
-            }
-            Event::NodeLost(node_lost, routing_table) => {
-                self.on_node_lost(node_lost, routing_table)
-            }
-            Event::RestartRequired => {
-                warn!("Restarting Vault");
-                ret = Some(false);
-                Ok(())
-            }
-            Event::Terminate => {
-                ret = Some(true);
-                Ok(())
-            }
-            Event::SectionSplit(_prefix) |
-            Event::SectionMerge(_prefix) => Ok(()),
-            Event::Connected | Event::Tick => Ok(()),
-        } {
+               Event::Request { request, src, dst } => self.on_request(request, src, dst),
+               Event::Response { response, src, dst } => self.on_response(response, src, dst),
+               Event::NodeAdded(node_added, routing_table) => {
+                   self.on_node_added(node_added, routing_table)
+               }
+               Event::NodeLost(node_lost, routing_table) => {
+                   self.on_node_lost(node_lost, routing_table)
+               }
+               Event::RestartRequired => {
+            warn!("Restarting Vault");
+            ret = Some(false);
+            Ok(())
+        }
+               Event::Terminate => {
+            ret = Some(true);
+            Ok(())
+        }
+               Event::SectionSplit(_prefix) |
+               Event::SectionMerge(_prefix) => Ok(()),
+               Event::Connected | Event::Tick => Ok(()),
+           } {
             debug!("Failed to handle event: {:?}", error);
         }
 

--- a/tests/data_manager.rs
+++ b/tests/data_manager.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -117,10 +117,10 @@ fn structured_data_parallel_posts() {
     let mut nodes = test_node::create_nodes(&network, node_count, None, false);
     let mut clients: Vec<_> = (0..3)
         .map(|_| {
-            let endpoint = unwrap!(rng.choose(&nodes), "no nodes found").endpoint();
-            let config = mock_crust::Config::with_contacts(&[endpoint]);
-            TestClient::new(&network, Some(config.clone()))
-        })
+                 let endpoint = unwrap!(rng.choose(&nodes), "no nodes found").endpoint();
+                 let config = mock_crust::Config::with_contacts(&[endpoint]);
+                 TestClient::new(&network, Some(config.clone()))
+             })
         .collect();
 
     for client in &mut clients {
@@ -247,25 +247,27 @@ fn structured_data_operations_with_churn() {
                 new_data.push(data);
             } else {
                 let j = Range::new(0, all_data.len()).ind_sample(&mut rng);
-                let data = Data::Structured(if let Data::Structured(sd) = all_data[j].clone() {
+                let sd = if let Data::Structured(sd) = all_data[j].clone() {
                     if !mutated_data.insert(sd.identifier()) {
                         trace!("Skipping data {:?} with name {:?}.",
                                sd.identifier(),
                                sd.name());
                         continue;
                     }
-                    let mut sd = unwrap!(StructuredData::new(sd.get_type_tag(),
-                                                             *sd.name(),
-                                                             sd.get_version() + 1,
-                                                             rng.gen_iter().take(10).collect(),
-                                                             sd.get_owners().clone()));
+                    let sd_result = StructuredData::new(sd.get_type_tag(),
+                                                        *sd.name(),
+                                                        sd.get_version() + 1,
+                                                        rng.gen_iter().take(10).collect(),
+                                                        sd.get_owners().clone());
+                    let mut sd = unwrap!(sd_result);
                     let pub_key = *client.full_id().public_id().signing_public_key();
                     let priv_key = client.full_id().signing_private_key().clone();
                     let _ = sd.add_signature(&(pub_key, priv_key));
                     sd
                 } else {
                     panic!("Non-structured data found.");
-                });
+                };
+                let data = Data::Structured(sd);
                 if false {
                     // FIXME: Delete tests are disabled right now.
                     trace!("Deleting data {:?} with name {:?}",
@@ -529,10 +531,10 @@ fn appendable_data_parallel_append() {
     let mut nodes = test_node::create_nodes(&network, node_count, None, false);
     let mut clients: Vec<_> = (0..2)
         .map(|_| {
-            let endpoint = unwrap!(rng.choose(&nodes), "no nodes found").endpoint();
-            let config = mock_crust::Config::with_contacts(&[endpoint]);
-            TestClient::new(&network, Some(config.clone()))
-        })
+                 let endpoint = unwrap!(rng.choose(&nodes), "no nodes found").endpoint();
+                 let config = mock_crust::Config::with_contacts(&[endpoint]);
+                 TestClient::new(&network, Some(config.clone()))
+             })
         .collect();
     for client in &mut clients {
         client.ensure_connected(&mut nodes);
@@ -603,10 +605,10 @@ fn appendable_data_parallel_post() {
     let mut nodes = test_node::create_nodes(&network, node_count, None, false);
     let mut clients: Vec<_> = (0..2)
         .map(|_| {
-            let endpoint = unwrap!(rng.choose(&nodes), "no nodes found").endpoint();
-            let config = mock_crust::Config::with_contacts(&[endpoint]);
-            TestClient::new(&network, Some(config.clone()))
-        })
+                 let endpoint = unwrap!(rng.choose(&nodes), "no nodes found").endpoint();
+                 let config = mock_crust::Config::with_contacts(&[endpoint]);
+                 TestClient::new(&network, Some(config.clone()))
+             })
         .collect();
     for client in &mut clients {
         client.ensure_connected(&mut nodes);
@@ -779,8 +781,11 @@ fn handle_post_error_flow() {
     let _ = client.put_and_verify(Data::Structured(sd.clone()), &mut nodes);
 
     // Posting with incorrect type_tag
-    let mut incorrect_tag_sd =
-        StructuredData::new(200000, *sd.name(), 1, sd.get_data().clone(), owner.clone())
+    let mut incorrect_tag_sd = StructuredData::new(200000,
+                                                   *sd.name(),
+                                                   1,
+                                                   sd.get_data().clone(),
+                                                   owner.clone())
             .expect("Cannot create structured data for test");
     let _ = incorrect_tag_sd.add_signature(&(pub_key, priv_key.clone()));
     match client.post_response(Data::Structured(incorrect_tag_sd), &mut nodes) {
@@ -789,8 +794,11 @@ fn handle_post_error_flow() {
     }
 
     // Posting with incorrect version
-    let mut incorrect_version_sd =
-        StructuredData::new(100000, *sd.name(), 3, sd.get_data().clone(), owner.clone())
+    let mut incorrect_version_sd = StructuredData::new(100000,
+                                                       *sd.name(),
+                                                       3,
+                                                       sd.get_data().clone(),
+                                                       owner.clone())
             .expect("Cannot create structured data for test");
     let _ = incorrect_version_sd.add_signature(&(pub_key, priv_key.clone()));
     match client.post_response(Data::Structured(incorrect_version_sd), &mut nodes) {
@@ -808,7 +816,7 @@ fn handle_post_error_flow() {
                                                       1,
                                                       sd.get_data().clone(),
                                                       new_owner.clone())
-        .expect("Cannot create structured data for test");
+            .expect("Cannot create structured data for test");
     let _ = incorrect_signed_sd.add_signature(&(new_pub_key, new_priv_key.clone()));
     match client.post_response(Data::Structured(incorrect_signed_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::InvalidSuccessor),
@@ -816,8 +824,11 @@ fn handle_post_error_flow() {
     }
 
     // Posting correctly
-    let mut new_sd =
-        StructuredData::new(100000, *sd.name(), 1, sd.get_data().clone(), owner.clone())
+    let mut new_sd = StructuredData::new(100000,
+                                         *sd.name(),
+                                         1,
+                                         sd.get_data().clone(),
+                                         owner.clone())
             .expect("Cannot create structured data for test");
     let _ = new_sd.add_signature(&(pub_key, priv_key));
     match client.post_response(Data::Structured(new_sd), &mut nodes) {
@@ -831,7 +842,7 @@ fn handle_post_error_flow() {
                                                2,
                                                rng.gen_iter().take(102400).collect(),
                                                new_owner.clone())
-        .expect("Cannot create structured data for test");
+            .expect("Cannot create structured data for test");
     let _ = oversized_sd.add_signature(&(new_pub_key, new_priv_key.clone()));
     match client.post_response(Data::Structured(oversized_sd), &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::DataTooLarge),
@@ -880,8 +891,11 @@ fn handle_delete_error_flow() {
     }
 
     // Deleting with incorrect version
-    let mut incorrect_version_sd =
-        StructuredData::new(100000, *sd.name(), 3, vec![], owner0.clone())
+    let mut incorrect_version_sd = StructuredData::new(100000,
+                                                       *sd.name(),
+                                                       3,
+                                                       vec![],
+                                                       owner0.clone())
             .expect("Cannot create structured data for test");
     let _ = incorrect_version_sd.add_signature(&(pub_key0, priv_key0.clone()));
     match client.delete_response(Data::Structured(incorrect_version_sd), &mut nodes) {
@@ -890,8 +904,11 @@ fn handle_delete_error_flow() {
     }
 
     // Deleting with incorrect signature
-    let mut incorrect_signed_sd =
-        StructuredData::new(100000, *sd.name(), 1, vec![], owner0.clone())
+    let mut incorrect_signed_sd = StructuredData::new(100000,
+                                                      *sd.name(),
+                                                      1,
+                                                      vec![],
+                                                      owner0.clone())
             .expect("Cannot create structured data for test");
     let _ = incorrect_signed_sd.add_signature(&(pub_key0, priv_key1.clone()));
     match client.delete_response(Data::Structured(incorrect_signed_sd), &mut nodes) {
@@ -900,8 +917,11 @@ fn handle_delete_error_flow() {
     }
 
     // Deleting
-    let mut new_sd =
-        StructuredData::new(100000, *sd.name(), 1, sd.get_data().clone(), owner0.clone())
+    let mut new_sd = StructuredData::new(100000,
+                                         *sd.name(),
+                                         1,
+                                         sd.get_data().clone(),
+                                         owner0.clone())
             .expect("Cannot create structured data for test");
     let _ = new_sd.add_signature(&(pub_key0, priv_key0.clone()));
     let deleted_data = Data::Structured(new_sd);
@@ -924,8 +944,11 @@ fn handle_delete_error_flow() {
     }
 
     // Deleted data cannot be posted
-    let mut post_sd =
-        StructuredData::new(100000, *sd.name(), 2, sd.get_data().clone(), owner0.clone())
+    let mut post_sd = StructuredData::new(100000,
+                                          *sd.name(),
+                                          2,
+                                          sd.get_data().clone(),
+                                          owner0.clone())
             .expect("Cannot create structured data for test");
     let _ = post_sd.add_signature(&(pub_key0, priv_key0.clone()));
     match client.post_response(Data::Structured(post_sd), &mut nodes) {
@@ -934,8 +957,11 @@ fn handle_delete_error_flow() {
     }
 
     // Deleted data cannot be put with version 0
-    let mut incorrect_reput_sd =
-        StructuredData::new(100000, *sd.name(), 0, sd.get_data().clone(), owner0.clone())
+    let mut incorrect_reput_sd = StructuredData::new(100000,
+                                                     *sd.name(),
+                                                     0,
+                                                     sd.get_data().clone(),
+                                                     owner0.clone())
             .expect("Cannot create structured data for test");
     let _ = incorrect_reput_sd.add_signature(&(pub_key0, priv_key0.clone()));
     match client.put_and_verify(Data::Structured(incorrect_reput_sd), &mut nodes) {
@@ -945,8 +971,11 @@ fn handle_delete_error_flow() {
 
     // Deleted data can be put with version + 1, even by a different owner.
     let owner1 = iter::once(pub_key1).collect::<BTreeSet<_>>();
-    let mut reput_sd =
-        StructuredData::new(100000, *sd.name(), 2, sd.get_data().clone(), owner1.clone())
+    let mut reput_sd = StructuredData::new(100000,
+                                           *sd.name(),
+                                           2,
+                                           sd.get_data().clone(),
+                                           owner1.clone())
             .expect("Cannot create structured data for test");
     let _ = reput_sd.add_signature(&(pub_key1, priv_key1.clone()));
     let reput_data = Data::Structured(reput_sd);

--- a/tests/maid_manager.rs
+++ b/tests/maid_manager.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -69,8 +69,9 @@ fn put_oversized_data() {
     client.ensure_connected(&mut nodes);
     client.create_account(&mut nodes);
 
-    match client.put_and_verify(Data::Immutable(
-            test_utils::random_immutable_data(1100 * 1024, &mut rng)), &mut nodes) {
+    match client.put_and_verify(Data::Immutable(test_utils::random_immutable_data(1100 * 1024,
+                                                                                  &mut rng)),
+                                &mut nodes) {
         Err(Some(error)) => assert_eq!(error, MutationError::DataTooLarge),
         unexpected => panic!("Got unexpected response: {:?}", unexpected),
     }
@@ -270,8 +271,10 @@ fn maid_manager_account_adding_with_churn() {
 
     for i in 0..test_utils::iterations() {
         for data in (0..4).map(|_| {
-            Data::Structured(test_utils::random_structured_data(100000, &full_id, &mut rng))
-        }) {
+                                   Data::Structured(test_utils::random_structured_data(100000,
+                                                                                       &full_id,
+                                                                                       &mut rng))
+                               }) {
             client.put(data.clone());
             put_count += 1;
         }
@@ -294,8 +297,10 @@ fn maid_manager_account_adding_with_churn() {
             node.clear_state();
         }
         trace!("Processed {} events.", event_count);
-        let mut sorted_maid_managers = nodes.iter()
-            .sorted_by(|left, right| client.name().cmp_distance(&left.name(), &right.name()));
+        let mut sorted_maid_managers =
+            nodes.iter().sorted_by(|left, right| {
+                                       client.name().cmp_distance(&left.name(), &right.name())
+                                   });
         sorted_maid_managers.truncate(GROUP_SIZE);
         let node_count_stats: Vec<(XorName, Option<u64>)> = sorted_maid_managers.into_iter()
             .map(|x| (x.name(), x.get_maid_manager_put_count(client.name())))
@@ -360,8 +365,10 @@ fn maid_manager_account_decrease_with_churn() {
             node.clear_state();
         }
         trace!("Processed {} events.", event_count);
-        let mut sorted_maid_managers = nodes.iter()
-            .sorted_by(|left, right| client.name().cmp_distance(&left.name(), &right.name()));
+        let mut sorted_maid_managers =
+            nodes.iter().sorted_by(|left, right| {
+                                       client.name().cmp_distance(&left.name(), &right.name())
+                                   });
         sorted_maid_managers.truncate(GROUP_SIZE);
         let node_count_stats: Vec<(XorName, Option<u64>)> = sorted_maid_managers.into_iter()
             .map(|x| (x.name(), x.get_maid_manager_put_count(client.name())))

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,8 +5,8 @@
 // licence you accepted on initial access to the Software (the "Licences").
 //
 // By contributing code to the SAFE Network Software, or to this project generally, you agree to be
-// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
-// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
 //
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
* fixed some outdated URLs
* removed mention of a version of the Contributor Agreement
* improved AppVeyor and Travis scripts
* added standard rustfmt.toml and applied rustfmt
* fixed clippy warnings