### PR TITLE
Replace rustc-serialize with serde (MAID-2040)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.13.2"
 [dependencies]
 accumulator = "~0.5.0"
 config_file_handler = "~0.4.0"
-docopt = "~0.6.86"
+clap = "~2.14.1"
 fs2 = "~0.2.5"
 itertools = "~0.5.9"
 lru_time_cache = "~0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,21 @@ version = "0.13.2"
 
 [dependencies]
 accumulator = "~0.5.0"
-config_file_handler = "~0.4.0"
+config_file_handler = { git = "https://github.com/maidsafe/config_file_handler.git", branch = "master" }
 clap = "~2.14.1"
 fs2 = "~0.2.5"
+hex = "~0.2.0"
 itertools = "~0.5.9"
 lru_time_cache = "~0.5.0"
 log = "~0.3.6"
-maidsafe_utilities = "~0.10.0"
+maidsafe_utilities = { git = "https://github.com/maidsafe/maidsafe_utilities.git", branch = "master" }
 quick-error = "~1.1.0"
 rand = "~0.3.14"
-routing = "~0.28.4"
-rustc-serialize = "~0.3.19"
-rust_sodium = "~0.1.2"
+routing = { git = "https://github.com/maidsafe/routing.git", branch = "master" }
+rust_sodium = { git = "https://github.com/maidsafe/rust_sodium.git", branch = "master" }
+serde = "~0.9.12"
+serde_derive = "~0.9.12"
+serde_json = "~0.9.9"
 tiny-keccak = "~1.2.0"
 unwrap = "~1.1.0"
 

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -19,9 +19,9 @@
 //! A simple, non-persistent, disk-based key-value store.
 
 use fs2::FileExt;
+use hex::{FromHex, ToHex};
 use maidsafe_utilities::serialisation::{self, SerialisationError};
-use rustc_serialize::{Decodable, Encodable};
-use rustc_serialize::hex::{FromHex, ToHex};
+use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
@@ -79,8 +79,8 @@ pub struct ChunkStore<Key, Value> {
 }
 
 impl<Key, Value> ChunkStore<Key, Value>
-    where Key: Decodable + Encodable,
-          Value: Decodable + Encodable
+    where Key: Serialize + Deserialize,
+          Value: Serialize + Deserialize
 {
     /// Creates a new `ChunkStore` with `max_space` allowed storage space.
     ///
@@ -170,8 +170,8 @@ impl<Key, Value> ChunkStore<Key, Value>
                     dir_entry
                         .ok()
                         .and_then(|entry| entry.file_name().into_string().ok())
-                        .and_then(|hex_name| hex_name.from_hex().ok())
-                        .and_then(|bytes| serialisation::deserialise::<Key>(&*bytes).ok())
+                        .and_then(|hex_name| FromHex::from_hex(hex_name.into_bytes()).ok())
+                        .and_then(|bytes: Vec<u8>| serialisation::deserialise::<Key>(&*bytes).ok())
                 };
                 Ok(dir_entries
                        .filter_map(dir_entry_to_routing_name)

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -21,7 +21,7 @@ use routing::XorName;
 use std::ffi::OsString;
 
 /// Lets a vault configure a wallet address and storage limit.
-#[derive(Clone, Debug, Default, RustcDecodable, RustcEncodable)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Config {
     /// Used to store the address where SafeCoin will be sent.
     pub wallet_address: Option<XorName>,
@@ -49,14 +49,14 @@ pub fn read_config_file() -> Result<Config, InternalError> {
 #[cfg(test)]
 #[allow(dead_code)]
 pub fn write_config_file(config: &Config) -> Result<::std::path::PathBuf, InternalError> {
-    use rustc_serialize::json;
+    use serde_json;
     use std::fs::File;
     use std::io::Write;
 
     let mut config_path = config_file_handler::current_bin_dir()?;
     config_path.push(get_file_name()?);
     let mut file = File::create(&config_path)?;
-    write!(&mut file, "{}", json::as_pretty_json(&config))?;
+    write!(&mut file, "{}", serde_json::to_string_pretty(&config)?)?;
     file.sync_all()?;
     Ok(config_path)
 }
@@ -75,7 +75,7 @@ mod test {
         use std::fs::File;
         use std::io::Read;
         use super::Config;
-        use rustc_serialize::json;
+        use serde_json;
 
         let path = Path::new("installer/common/sample.vault.config").to_path_buf();
 
@@ -92,7 +92,7 @@ mod test {
             panic!(format!("Error reading safe_vault.vault.config: {:?}", what));
         }
 
-        if let Err(what) = json::decode::<Config>(&encoded_contents) {
+        if let Err(what) = serde_json::from_str::<Config>(&encoded_contents) {
             panic!(format!("Error parsing safe_vault.vault.config: {:?}", what));
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ use maidsafe_utilities::serialisation::SerialisationError;
 use routing::{InterfaceError, MessageId, Request, Response, RoutingError};
 use routing::client_errors::{GetError, MutationError};
 use routing::messaging;
+use serde_json;
 use std::io;
 
 quick_error! {
@@ -52,6 +53,9 @@ quick_error! {
             from()
         }
         Serialisation(error: SerialisationError) {
+            from()
+        }
+        JsonSerialisaion(error: serde_json::Error) {
             from()
         }
         UnknownRequestType(request: Request)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,9 +197,9 @@
 
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(bad_style, exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
+#![forbid(exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
           unknown_crate_types, warnings)]
-#![deny(deprecated, improper_ctypes, missing_docs,
+#![deny(bad_style, deprecated, improper_ctypes, missing_docs,
         non_shorthand_field_patterns, overflowing_literals, plugin_as_library,
         private_no_mangle_fns, private_no_mangle_statics, stable_features, unconditional_recursion,
         unknown_lints, unsafe_code, unused, unused_allocation, unused_attributes,
@@ -207,13 +207,14 @@
 #![warn(trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
         unused_qualifications, unused_results)]
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
-         missing_debug_implementations, variant_size_differences)]
+         missing_debug_implementations, variant_size_differences, non_upper_case_globals)]
 
 // TODO solve this
 #![cfg_attr(feature="cargo-clippy", allow(large_enum_variant))]
 
 extern crate accumulator;
 extern crate fs2;
+extern crate hex;
 #[macro_use]
 extern crate log;
 extern crate lru_time_cache;
@@ -225,8 +226,11 @@ extern crate quick_error;
 #[cfg(any(test, feature = "use-mock-crust"))]
 extern crate rand;
 extern crate routing;
-extern crate rustc_serialize;
 extern crate rust_sodium;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 #[cfg(test)]
 extern crate tempdir;
 extern crate tiny_keccak;

--- a/src/mock_crust_detail/test_client.rs
+++ b/src/mock_crust_detail/test_client.rs
@@ -18,8 +18,8 @@
 use super::poll;
 use super::test_node::TestNode;
 use GROUP_SIZE;
-use maidsafe_utilities::serialisation;
-use rand::{Rng, XorShiftRng};
+use maidsafe_utilities::{SeededRng, serialisation};
+use rand::Rng;
 use routing::{self, AppendWrapper, Authority, Data, DataIdentifier, Event, FullId, MessageId,
               PublicId, Response, StructuredData, XorName};
 use routing::client_errors::{GetError, MutationError};
@@ -35,7 +35,7 @@ pub struct TestClient {
     full_id: FullId,
     public_id: PublicId,
     name: XorName,
-    rng: XorShiftRng,
+    rng: SeededRng,
 }
 
 impl TestClient {

--- a/src/mock_crust_detail/test_node.rs
+++ b/src/mock_crust_detail/test_node.rs
@@ -17,11 +17,11 @@
 
 use super::poll;
 use config_handler::Config;
+use hex::ToHex;
 use personas::data_manager::IdAndVersion;
 use rand::{self, Rng};
 use routing::{RoutingTable, XorName};
 use routing::mock_crust::{self, Endpoint, Network, ServiceHandle};
-use rustc_serialize::hex::ToHex;
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/src/personas/data_manager.rs
+++ b/src/personas/data_manager.rs
@@ -62,7 +62,7 @@ struct PendingWrite {
     rejected: bool,
 }
 
-#[derive(Clone, RustcEncodable)]
+#[derive(Clone, Serialize)]
 enum PendingMutationType {
     Append,
     Put,
@@ -1246,10 +1246,10 @@ impl DataManager {
 }
 
 /// A list of data held by the sender. Sent from node to node.
-#[derive(RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 struct RefreshDataList(Vec<IdAndVersion>);
 
 /// A message from the group to itself to store the given data. If this accumulates, that means a
 /// quorum of group members approves.
-#[derive(RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Copy, Clone)]
 struct RefreshData(IdAndVersion, sha3::Digest256);

--- a/src/personas/maid_manager.rs
+++ b/src/personas/maid_manager.rs
@@ -34,13 +34,13 @@ const DEFAULT_ACCOUNT_SIZE: u64 = 500;
 #[cfg(feature = "use-mock-crust")]
 const DEFAULT_ACCOUNT_SIZE: u64 = 100;
 
-#[derive(RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 enum Refresh {
     Update(XorName, Account),
     Delete(XorName),
 }
 
-#[derive(RustcEncodable, RustcDecodable, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Account {
     data_stored: u64,
     space_available: u64,


### PR DESCRIPTION
Also replaces `docopt` (which depends on `rustc-serialize`) with `clap` (without any extra dependencies)