### PR TITLE
(WIP) Limit concurrent mutations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ log = "~0.3.7"
 maidsafe_utilities = "~0.12.1"
 quick-error = "~1.1.0"
 rand = "~0.3.14"
-routing = { git = "https://github.com/maidsafe/routing", branch = "mutable-data" }
+# routing = { git = "https://github.com/maidsafe/routing", branch = "mutable-data" }
+routing = { git = "https://github.com/madadam/routing", branch = "mdata-validation-improvements" }
 rust_sodium = "~0.3.0"
 serde = "~1.0.6"
 serde_derive = "~1.0.6"

--- a/src/personas/data_manager/mutation.rs
+++ b/src/personas/data_manager/mutation.rs
@@ -124,6 +124,38 @@ impl Mutation {
             _ => false,
         }
     }
+
+    /// Apply the mutation to the mutable data, without performing any validations.
+    pub fn apply(&self, data: &mut MutableData) {
+        assert_eq!(DataId::Mutable(data.id()), self.data_id());
+
+        match *self {
+            Mutation::MutateMDataEntries { ref actions, .. } => {
+                data.mutate_entries_without_validation(actions.clone())
+            }
+            Mutation::SetMDataUserPermissions {
+                user,
+                permissions,
+                version,
+                ..
+            } => {
+                let _ = data.set_user_permissions_without_validation(user, permissions, version);
+            }
+            Mutation::DelMDataUserPermissions { ref user, version, .. } => {
+                let _ = data.del_user_permissions_without_validation(user, version);
+            }
+            Mutation::ChangeMDataOwner {
+                ref new_owners,
+                version,
+                ..
+            } => {
+                if let Some(owner) = new_owners.iter().next() {
+                    let _ = data.change_owner_without_validation(*owner, version);
+                }
+            }
+            _ => panic!("incompatible mutation ({:?})", self.mutation_type()),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/personas/data_manager/tests.rs
+++ b/src/personas/data_manager/tests.rs
@@ -17,6 +17,7 @@
 
 use super::*;
 use QUORUM;
+use maidsafe_utilities::SeededRng;
 use maidsafe_utilities::serialisation::{deserialise, serialise};
 use mock_routing::RequestWrapper;
 use rand::{self, Rng};
@@ -32,10 +33,12 @@ const TEST_TAG: u64 = 12345678;
 
 #[test]
 fn idata_basics() {
+    let mut rng = SeededRng::new();
+
     let (client, client_key) = test_utils::gen_client_authority();
     let client_manager = test_utils::gen_client_manager_authority(client_key);
 
-    let data = test_utils::gen_immutable_data(10, &mut rand::thread_rng());
+    let data = test_utils::gen_immutable_data(10, &mut rng);
     let nae_manager = Authority::NaeManager(*data.name());
 
     let mut node = RoutingNode::new();
@@ -75,7 +78,7 @@ fn idata_basics() {
 
 #[test]
 fn mdata_basics() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let (client, client_key) = test_utils::gen_client_authority();
     let client_manager = test_utils::gen_client_manager_authority(client_key);
@@ -137,7 +140,7 @@ fn mdata_basics() {
 
 #[test]
 fn mdata_mutations() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let (client, client_key) = test_utils::gen_client_authority();
     let client_manager = test_utils::gen_client_manager_authority(client_key);
@@ -223,7 +226,7 @@ fn mdata_mutations() {
 
 #[test]
 fn mdata_change_owner() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let (_, client_key_0) = test_utils::gen_client_authority();
     let client_manager_0 = test_utils::gen_client_manager_authority(client_key_0);
@@ -283,7 +286,7 @@ fn mdata_change_owner() {
 
 #[test]
 fn handle_node_added() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let mut node = RoutingNode::new();
     let mut dm = create_data_manager();
@@ -350,7 +353,7 @@ fn handle_node_added() {
 //    no more requests.
 #[test]
 fn idata_with_churn() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let (mut new_node, mut new_dm, old_node_names) = setup_churn(&mut rng);
 
@@ -425,7 +428,7 @@ fn idata_with_churn() {
 //    entries individually.
 #[test]
 fn mdata_with_churn() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let (_, client_key) = test_utils::gen_client_authority();
     let data = test_utils::gen_mutable_data(TEST_TAG, 2, client_key, &mut rng);
@@ -453,7 +456,7 @@ fn mdata_with_churn() {
 // Same as `mdata_with_churn` except only a subset of the data entries accumulate.
 #[test]
 fn mdata_with_churn_with_partial_accumulation() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let (_, client_key) = test_utils::gen_client_authority();
     let data = test_utils::gen_mutable_data(TEST_TAG, 3, client_key, &mut rng);
@@ -508,7 +511,7 @@ fn mdata_with_churn_with_partial_accumulation() {
 // Same as `mdata_with_churn`, except entries now accumulate before shell.
 #[test]
 fn mdata_with_churn_with_entries_accumulating_before_shell() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let (_, client_key) = test_utils::gen_client_authority();
     let data = test_utils::gen_mutable_data(TEST_TAG, 1, client_key, &mut rng);
@@ -547,7 +550,7 @@ fn mdata_with_churn_with_entries_accumulating_before_shell() {
 
 #[test]
 fn mdata_non_conflicting_parallel_mutations() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let mut node = RoutingNode::new();
     let mut dm = create_data_manager();
@@ -624,7 +627,7 @@ fn mdata_non_conflicting_parallel_mutations() {
 
 #[test]
 fn mdata_conflicting_parallel_mutations() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let mut node = RoutingNode::new();
     let mut dm = create_data_manager();
@@ -695,7 +698,7 @@ fn mdata_conflicting_parallel_mutations() {
 
 #[test]
 fn mdata_parallel_mutations_limits() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SeededRng::new();
 
     let mut node = RoutingNode::new();
     let mut dm = create_data_manager();
@@ -758,7 +761,7 @@ fn mdata_parallel_mutations_limits() {
     let payload = assert_match!(message.request, Request::Refresh(payload, _) => payload);
     unwrap!(dm.handle_group_refresh(&mut node, &payload));
 
-    // Both request should succeed.
+    // Both requests should succeed.
     let message = unwrap!(node.sent_responses.remove(&msg_id_0));
     assert_match!(message.response, Response::MutateMDataEntries { res: Ok(()), .. });
 

--- a/tests/data_manager.rs
+++ b/tests/data_manager.rs
@@ -156,6 +156,8 @@ fn immutable_data_operations_with_churn(use_cache: bool) {
 fn mutable_data_normal_flow() {
     let seed = None;
     let node_count = TEST_NET_SIZE;
+    let num_entries = 10;
+    let num_entry_actions = 10;
 
     let network = Network::new(GROUP_SIZE, seed);
     let mut rng = network.new_rng();
@@ -168,7 +170,8 @@ fn mutable_data_normal_flow() {
     client.create_account(&mut nodes);
 
     // Put mutable data
-    let mut data = test_utils::gen_mutable_data(10000, 10, *client.signing_public_key(), &mut rng);
+    let mut data =
+        test_utils::gen_mutable_data(10000, num_entries, *client.signing_public_key(), &mut rng);
     unwrap!(client.put_mdata_response(data.clone(), &mut nodes));
 
     // Get the shell and entries and verify they are what we put it.
@@ -189,7 +192,7 @@ fn mutable_data_normal_flow() {
     }
 
     // Mutate and verify the data.
-    let actions = test_utils::gen_mutable_data_entry_actions(&data, 10, &mut rng);
+    let actions = test_utils::gen_mutable_data_entry_actions(&data, num_entry_actions, &mut rng);
     unwrap!(data.mutate_entries(actions.clone(), *client.signing_public_key()));
     unwrap!(client.mutate_mdata_entries_response(*data.name(), data.tag(), actions, &mut nodes));
     let received_entries =

--- a/tests/data_manager.rs
+++ b/tests/data_manager.rs
@@ -21,8 +21,8 @@
 use fake_clock::FakeClock;
 use rand::Rng;
 use routing::{Action, Authority, BootstrapConfig, ClientError, EntryAction, EntryActions, Event,
-              ImmutableData, MAX_MUTABLE_DATA_ENTRY_ACTIONS, MessageId, MutableData,
-              PermissionSet, Response, User};
+              ImmutableData, MAX_MUTABLE_DATA_ENTRIES, MessageId, MutableData, PermissionSet,
+              Response, User};
 use routing::mock_crust::Network;
 use rust_sodium::crypto::sign;
 use safe_vault::{GROUP_SIZE, PENDING_WRITE_TIMEOUT_SECS, test_utils};
@@ -189,10 +189,7 @@ fn mutable_data_normal_flow() {
     }
 
     // Mutate and verify the data.
-    let actions = test_utils::gen_mutable_data_entry_actions(&data,
-                                                             MAX_MUTABLE_DATA_ENTRY_ACTIONS as
-                                                             usize,
-                                                             &mut rng);
+    let actions = test_utils::gen_mutable_data_entry_actions(&data, 10, &mut rng);
     unwrap!(data.mutate_entries(actions.clone(), *client.signing_public_key()));
     unwrap!(client.mutate_mdata_entries_response(*data.name(), data.tag(), actions, &mut nodes));
     let received_entries =
@@ -424,11 +421,10 @@ fn mutable_data_error_flow() {
                                                   &mut nodes),
                   Err(ClientError::NoSuchEntry));
 
-    // Mutating with too many entry actions fails.
-    let actions =
-        test_utils::gen_mutable_data_entry_actions(&data,
-                                                   MAX_MUTABLE_DATA_ENTRY_ACTIONS as usize + 1,
-                                                   &mut rng);
+    // Mutating with too many entries fails.
+    let actions = test_utils::gen_mutable_data_entry_actions(&data,
+                                                             MAX_MUTABLE_DATA_ENTRIES as usize + 1,
+                                                             &mut rng);
     assert_match!(client.mutate_mdata_entries_response(*data.name(), 10000, actions, &mut nodes),
                   Err(ClientError::TooManyEntries));
 
@@ -635,7 +631,7 @@ fn mutable_data_parallel_mutations() {
             .iter_mut()
             .map(|client| {
                 let data = &all_data[j];
-                let num_actions = rng.gen_range(1, MAX_MUTABLE_DATA_ENTRY_ACTIONS as usize);
+                let num_actions = rng.gen_range(1, 10);
                 let actions =
                     test_utils::gen_mutable_data_entry_actions(data, num_actions, &mut rng);
 
@@ -648,7 +644,7 @@ fn mutable_data_parallel_mutations() {
             })
             .collect();
 
-        event_count += poll::nodes_and_clients_parallel_with_resend(&mut nodes, &mut clients);
+        event_count += poll::nodes_and_clients_parallel(&mut nodes, &mut clients);
         trace!("Processed {} events.", event_count);
 
         // Collect the responses from the clients. For those that succeed,
@@ -662,10 +658,10 @@ fn mutable_data_parallel_mutations() {
                        } = event {
                     match res {
                         Ok(()) => {
-                                trace!("Client {:?} received success response.",
-                                       client.name());
-                                unwrap!(data.mutate_entries(actions, *client.signing_public_key()));
-                            }
+                            trace!("Client {:?} received success response.",
+                                   client.name());
+                            unwrap!(data.mutate_entries(actions, *client.signing_public_key()));
+                        }
                         Err(error) => {
                             trace!("Client {:?} received failed response. Reason: {:?}",
                                    client.name(),
@@ -676,6 +672,7 @@ fn mutable_data_parallel_mutations() {
                 }
             }
         }
+
         // Check the new version of data (on success) has been stored properly; or confirm the old
         // version of data (on failure or no response) still keeps untouched.
         mock_crust_detail::check_data(all_data.iter().cloned().map(Data::Mutable).collect(),
@@ -749,7 +746,7 @@ fn mutable_data_concurrent_mutations() {
         {
             let data = &all_data[index];
             for _ in 0..2 {
-                let num_actions = rng.gen_range(1, MAX_MUTABLE_DATA_ENTRY_ACTIONS as usize);
+                let num_actions = rng.gen_range(1, 10);
                 let actions =
                     test_utils::gen_mutable_data_entry_actions(data, num_actions, &mut rng);
                 {
@@ -897,7 +894,7 @@ fn no_permission_mutable_data_concurrent_mutations() {
         let data_name = *all_data[index].name();
         let data_tag = all_data[index].tag();
 
-        let num_actions = rng.gen_range(1, MAX_MUTABLE_DATA_ENTRY_ACTIONS as usize);
+        let num_actions = rng.gen_range(1, 10);
         let actions =
             test_utils::gen_mutable_data_entry_actions(&all_data[index], num_actions, &mut rng);
 
@@ -1015,7 +1012,7 @@ fn mutable_data_operations_with_churn() {
                     continue;
                 }
 
-                let action_count = rng.gen_range(1, MAX_MUTABLE_DATA_ENTRY_ACTIONS as usize + 1);
+                let action_count = rng.gen_range(1, 10);
                 let actions =
                     test_utils::gen_mutable_data_entry_actions(data, action_count, &mut rng);
                 unwrap!(data.mutate_entries(actions.clone(), *client.signing_public_key()));


### PR DESCRIPTION
**DO NOT MERGE** yet. Requires https://github.com/maidsafe/routing/pull/1469.

This PR implements limit on the number of concurrent mutations against the same data chunk. In particular, it allow a mutation only if it, together with all the other pending mutations, increments the the number of entries and/or size by at most half of the respective remaining allowance. 