### PR TITLE
MAID-2099: add dev config options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,17 +25,15 @@ quick-error = "~1.1.0"
 rand = "~0.3.14"
 routing = "~0.31.0"
 rust_sodium = "~0.3.0"
-serde = "~1.0.6"
-serde_derive = "~1.0.6"
+serde = "~1.0.9"
+serde_derive = "~1.0.9"
 serde_json = "~1.0.2"
+tempdir = "~0.3.5"
 tiny-keccak = "~1.2.1"
 unwrap = "~1.1.0"
 
 [build-dependencies]
 hyper = {version = "~0.9.10", optional = true}
-
-[dev-dependencies]
-tempdir = "~0.3.5"
 
 [features]
 generate-diagrams = ["hyper"]

--- a/installer/common/sample.vault.config
+++ b/installer/common/sample.vault.config
@@ -1,5 +1,6 @@
 {
   "wallet_address": null,
   "max_capacity": 104857600,
-  "chunk_store_root": null
+  "chunk_store_root": null,
+  "dev": null
 }

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -28,10 +28,19 @@ pub struct Config {
     pub wallet_address: Option<XorName>,
     /// Upper limit for allowed network storage on this vault.
     pub max_capacity: Option<u64>, // measured by Bytes
-    /// root directory for chunk_store directories
+    /// Root directory for chunk_store directories
     pub chunk_store_root: Option<String>,
     /// Key that is allowed to put mutable data for account creation invitations.
     pub invite_key: Option<[u8; sign::PUBLICKEYBYTES]>,
+    /// Developer options
+    pub dev: Option<DevConfig>,
+}
+
+/// Extra configuration options intended for developers
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct DevConfig {
+    /// Allow to setup multiple nodes on a single local network
+    pub allow_multiple_lan_nodes: bool,
 }
 
 /// Reads the default vault config file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-#[cfg(test)]
 extern crate tempdir;
 extern crate tiny_keccak;
 #[macro_use]

--- a/src/mock_crust_detail/test_node.rs
+++ b/src/mock_crust_detail/test_node.rs
@@ -69,6 +69,7 @@ impl TestNode {
                     max_capacity: None,
                     chunk_store_root: Some(format!("{}", chunk_store_root.display())),
                     invite_key: None,
+                    dev: None,
                 }
             }
         };

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -39,8 +39,8 @@ use routing::NodeBuilder;
 #[cfg(not(feature = "use-mock-crust"))]
 use rust_sodium;
 use rust_sodium::crypto::sign;
-use std::env;
 use std::path::Path;
+use tempdir::TempDir;
 
 pub const CHUNK_STORE_DIR: &'static str = "safe_vault_chunk_store";
 const DEFAULT_MAX_CAPACITY: u64 = 2 * 1024 * 1024 * 1024;
@@ -50,6 +50,9 @@ pub struct Vault {
     maid_manager: MaidManager,
     data_manager: DataManager,
     routing_node: RoutingNode,
+    // We need to store this field for `TempDir` to remain valid
+    // for the time of the vault existence.
+    _chunk_root_tmp_dir: Option<TempDir>,
 }
 
 impl Vault {
@@ -63,9 +66,17 @@ impl Vault {
             }
             Err(e) => return Err(From::from(e)),
         };
-        let builder = RoutingNode::builder()
-            .first(first_vault)
-            .deny_other_local_nodes();
+        let mut builder = RoutingNode::builder().first(first_vault);
+
+        let deny_other_local_nodes =
+            config
+                .dev
+                .as_ref()
+                .map_or(true, |dev_config| !dev_config.allow_multiple_lan_nodes);
+        if deny_other_local_nodes {
+            builder = builder.deny_other_local_nodes();
+        }
+
         match Self::vault_with_config(builder, use_cache, config.clone()) {
             Ok(vault) => Ok(vault),
             Err(InternalError::ChunkStore(e)) => {
@@ -86,11 +97,14 @@ impl Vault {
         #[cfg(not(feature = "use-mock-crust"))]
         rust_sodium::init();
 
-        let mut chunk_store_root = match config.chunk_store_root {
-            Some(path_str) => Path::new(&path_str).to_path_buf(),
-            None => env::temp_dir(),
+        let (tmp_dir, chunk_store_root) = match config.chunk_store_root {
+            Some(path_str) => (None, Path::new(&path_str).to_path_buf()),
+            None => {
+                let tmp_dir = TempDir::new(CHUNK_STORE_DIR)?;
+                let path_buf = tmp_dir.path().to_path_buf();
+                (Some(tmp_dir), path_buf)
+            }
         };
-        chunk_store_root.push(CHUNK_STORE_DIR);
 
         let routing_node = if use_cache {
             builder.cache(Box::new(Cache::new())).create()
@@ -103,6 +117,7 @@ impl Vault {
                data_manager: DataManager::new(chunk_store_root,
                                               config.max_capacity.unwrap_or(DEFAULT_MAX_CAPACITY))?,
                routing_node: routing_node,
+               _chunk_root_tmp_dir: tmp_dir,
            })
 
     }

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -45,6 +45,7 @@ fn fill_network() {
         max_capacity: Some(2000),
         chunk_store_root: None,
         invite_key: None,
+        dev: None,
     };
 
     let mut nodes = test_node::create_nodes(&network, 8, Some(config), true);


### PR DESCRIPTION
Add dev configuration option to allow running multiple nodes on the same local network.

Also, change handling of chunk store root: instead of using a single hard-coded path create a temp directory with a random name (with a prefix) for each vault run. If you want a stable name, just provide it in the vault config file as the `chunk_store_root` config value.