### PR TITLE
MAID-2259 refactor/rate_limiter: removes proxy rate exceed event.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
  "maidsafe_utilities 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "routing 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "routing 0.32.2 (git+https://github.com/maidsafe/routing)",
  "rust_sodium 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "routing"
 version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/maidsafe/routing#57a18a6b974628c3be032ca97aced362f1714a9a"
 dependencies = [
  "config_file_handler 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crust 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1333,7 +1333,7 @@ dependencies = [
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum resource_proof 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9eaa71a03a0cd0d41a32dfb3c5234c66658e6fa41d53785c5290d86465328215"
-"checksum routing 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2627898ae845bb41591633f8073ae484272cd2b4cec1f13fd12e7422396fb"
+"checksum routing 0.32.2 (git+https://github.com/maidsafe/routing)" = "<none>"
 "checksum rust_sodium 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a38db456cdc9ecfd4dbe52b7eb0976f05414a5a7fe4e80300f90598bbf9597"
 "checksum rust_sodium-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "209996fa5e69b106aad826f860047ad2aaa280ea01e1c9f43406a2979970601b"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lru_time_cache = "~0.7.0"
 maidsafe_utilities = "~0.14.0"
 quick-error = "~1.2.0"
 rand = "~0.3.16"
-routing = "~0.32.2"
+routing = { git="https://github.com/maidsafe/routing", branch="master" }
 rust_sodium = "~0.5.0"
 serde = "~1.0.11"
 serde_derive = "~1.0.11"

--- a/src/mock_crust_detail/poll.rs
+++ b/src/mock_crust_detail/poll.rs
@@ -81,14 +81,18 @@ pub fn nodes_and_clients(
     count
 }
 
-/// Empty event queue of nodes and client, until there are no unacknowledged messages
-/// left.
+/// Empty event queue of nodes and client, until there are no unacknowledged messages left.
 pub fn nodes_and_client_with_resend(nodes: &mut [TestNode], client: &mut TestClient) -> usize {
+    nodes_and_clients_with_resend(nodes, ref_slice_mut(client))
+}
+
+/// Empty event queue of nodes and clients, until there are no unacknowledged messages left.
+pub fn nodes_and_clients_with_resend(nodes: &mut [TestNode], clients: &mut [TestClient]) -> usize {
     let mut fired_connected_peer_timeout = false;
     let mut total_count = 0;
 
     for _ in 0..MAX_POLL_CALLS {
-        let count = nodes_and_client(nodes, client);
+        let count = nodes_and_clients(nodes, clients, false);
         if count > 0 {
             // Once each route is polled, advance time to trigger the following route.
             FakeClock::advance_time(ACK_TIMEOUT_SECS * 1000 + 1);

--- a/src/mock_crust_detail/poll.rs
+++ b/src/mock_crust_detail/poll.rs
@@ -18,7 +18,7 @@
 use super::test_client::TestClient;
 use super::test_node::TestNode;
 use fake_clock::FakeClock;
-use routing::test_consts::{ACK_TIMEOUT_SECS, CONNECTED_PEER_TIMEOUT_SECS};
+use routing::test_consts::{ACK_TIMEOUT_SECS, CONNECTED_PEER_TIMEOUT_SECS, RATE_EXCEED_RETRY_MS};
 
 // Maximum number of times to try and poll in a loop.  This is several orders higher than the
 // anticipated upper limit for any test, and if hit is likely to indicate an infinite loop.
@@ -26,32 +26,55 @@ const MAX_POLL_CALLS: usize = 1000;
 
 /// Empty event queue of nodes provided
 pub fn nodes(nodes: &mut [TestNode]) -> usize {
-    nodes_and_clients(nodes, &mut [])
+    nodes_and_clients(nodes, &mut [], false)
 }
 
 /// Empty event queue of nodes and the client provided
 pub fn nodes_and_client(nodes: &mut [TestNode], client: &mut TestClient) -> usize {
-    nodes_and_clients(nodes, ref_slice_mut(client))
+    nodes_and_clients(nodes, ref_slice_mut(client), false)
 }
 
 /// Empty event queue of nodes and clients provided
-pub fn nodes_and_clients(nodes: &mut [TestNode], clients: &mut [TestClient]) -> usize {
+pub fn nodes_and_clients(
+    nodes: &mut [TestNode],
+    clients: &mut [TestClient],
+    parallel_poll: bool,
+) -> usize {
     let mut count: usize = 0;
-
+    let mut fired_rate_exceeded_timeout = false;
     loop {
         nodes[0].handle.deliver_messages();
         let prev_count = count;
 
         for node in nodes.iter_mut() {
-            count += node.poll();
+            if parallel_poll {
+                if node.poll_once() {
+                    count += 1;
+                }
+            } else {
+                count += node.poll();
+            }
         }
 
         for client in clients.iter_mut() {
-            count += client.poll();
+            if parallel_poll {
+                if client.poll_once() {
+                    count += 1;
+                }
+            } else {
+                count += client.poll();
+            }
         }
 
         if prev_count == count {
-            break;
+            if !fired_rate_exceeded_timeout {
+                fired_rate_exceeded_timeout = true;
+                FakeClock::advance_time(RATE_EXCEED_RETRY_MS + 1);
+            } else {
+                break;
+            }
+        } else {
+            fired_rate_exceeded_timeout = false;
         }
     }
 
@@ -61,74 +84,23 @@ pub fn nodes_and_clients(nodes: &mut [TestNode], clients: &mut [TestClient]) -> 
 /// Empty event queue of nodes and client, until there are no unacknowledged messages
 /// left.
 pub fn nodes_and_client_with_resend(nodes: &mut [TestNode], client: &mut TestClient) -> usize {
-    with_resend(|| nodes_and_client(nodes, client))
-}
-
-/// Empty event queue of nodes and clients, until there are no unacknowledged messages
-/// left.
-pub fn nodes_and_clients_with_resend(nodes: &mut [TestNode], clients: &mut [TestClient]) -> usize {
-    with_resend(|| nodes_and_clients(nodes, clients))
-}
-
-/// Empty event queue of nodes and clients.
-/// Handles more than one client and handles only one event per round for each node and client,
-/// to better simulate simultaneous requests.
-pub fn nodes_and_clients_parallel(nodes: &mut [TestNode], clients: &mut [TestClient]) -> usize {
-    let mut count = 0;
-    loop {
-        nodes[0].handle.deliver_messages();
-        let prev_count = count;
-
-        for node in nodes.iter_mut() {
-            if node.poll_once() {
-                count += 1;
-            }
-        }
-
-        for client in clients.iter_mut() {
-            if client.poll_once() {
-                count += 1;
-            }
-        }
-
-        if prev_count == count {
-            break;
-        }
-    }
-    count
-}
-
-/// Empty event queue of nodes and clients, until there are no unacknowledged messages
-/// left. Handles only one event per round for each node and client to better simulate
-/// simultaneous requests.
-pub fn nodes_and_clients_parallel_with_resend(
-    nodes: &mut [TestNode],
-    clients: &mut [TestClient],
-) -> usize {
-    with_resend(|| nodes_and_clients_parallel(nodes, clients))
-}
-
-fn with_resend<F>(mut f: F) -> usize
-where
-    F: FnMut() -> usize,
-{
-    let clock_advance_duration_ms = ACK_TIMEOUT_SECS * 1000 + 1;
-    let mut clock_advanced_by_ms = 0;
-    let mut count = 0;
+    let mut fired_connected_peer_timeout = false;
+    let mut total_count = 0;
 
     for _ in 0..MAX_POLL_CALLS {
-        let prev_count = count;
-        count += f();
-        if count > prev_count {
-            clock_advanced_by_ms = 0;
-        } else if clock_advanced_by_ms > (CONNECTED_PEER_TIMEOUT_SECS * 1000) {
-            return count;
+        let count = nodes_and_client(nodes, client);
+        if count > 0 {
+            // Once each route is polled, advance time to trigger the following route.
+            FakeClock::advance_time(ACK_TIMEOUT_SECS * 1000 + 1);
+            total_count += count;
+        } else if !fired_connected_peer_timeout {
+            // When all routes are polled, advance time to purge any invalid peers.
+            FakeClock::advance_time(CONNECTED_PEER_TIMEOUT_SECS * 1000 + 1);
+            fired_connected_peer_timeout = true;
+        } else {
+            return total_count;
         }
-
-        FakeClock::advance_time(clock_advance_duration_ms);
-        clock_advanced_by_ms += clock_advance_duration_ms;
     }
-
     panic!("Polling has been called {} times.", MAX_POLL_CALLS);
 }
 

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -133,8 +133,7 @@ impl Vault {
             Event::SectionSplit(_) |
             Event::SectionMerge(_) |
             Event::Connected |
-            Event::Tick |
-            Event::ProxyRateLimitExceeded(_) => {
+            Event::Tick => {
                 res = EventResult::Ignored;
                 Ok(())
             }

--- a/tests/data_manager.rs
+++ b/tests/data_manager.rs
@@ -799,7 +799,7 @@ fn mutable_data_parallel_mutations() {
             })
             .collect();
 
-        event_count += poll::nodes_and_clients_parallel(&mut nodes, &mut clients);
+        event_count += poll::nodes_and_clients(&mut nodes, &mut clients, true);
         trace!("Processed {} events.", event_count);
 
         // Collect the responses from the clients. For those that succeed,
@@ -1061,17 +1061,17 @@ fn mutable_data_put_and_mutate() {
         let node_index = rng.gen_range(0, nodes.len());
         nodes[node_index].delay_group_refreshes(true);
 
-        event_count += poll::nodes_and_clients(&mut nodes, &mut clients);
+        event_count += poll::nodes_and_clients(&mut nodes, &mut clients, false);
         trace!("Processed {} events.", event_count);
 
         let actions = test_utils::gen_mutable_data_entry_actions(&data, 1, &mut rng);
         let _ = clients[1].mutate_mdata_entries(*data.name(), data.tag(), actions.clone());
 
-        event_count += poll::nodes_and_clients(&mut nodes, &mut clients);
+        event_count += poll::nodes_and_clients(&mut nodes, &mut clients, false);
         nodes[node_index].delay_group_refreshes(false);
         // Required to ensure the group leader handle delayed group refresh messages.
         // Hence the response to the client is guaranteed to be sent.
-        event_count += poll::nodes_and_clients(&mut nodes, &mut clients);
+        event_count += poll::nodes_and_clients(&mut nodes, &mut clients, false);
         trace!("Processed {} events.", event_count);
 
         while let Ok(event) = clients[0].try_recv() {
@@ -1204,7 +1204,7 @@ fn no_permission_mutable_data_concurrent_mutations() {
         let _ = clients[0].mutate_mdata_entries(data_name, data_tag, actions.clone());
         let _ = clients[1].mutate_mdata_entries(data_name, data_tag, actions.clone());
 
-        event_count += poll::nodes_and_clients_parallel(&mut nodes, &mut clients);
+        event_count += poll::nodes_and_clients(&mut nodes, &mut clients, true);
         trace!("Processed {} events.", event_count);
 
         let mut network_responded = false;

--- a/tests/data_manager.rs
+++ b/tests/data_manager.rs
@@ -1071,7 +1071,9 @@ fn mutable_data_put_and_mutate() {
         nodes[node_index].delay_group_refreshes(false);
         // Required to ensure the group leader handle delayed group refresh messages.
         // Hence the response to the client is guaranteed to be sent.
-        event_count += poll::nodes_and_clients(&mut nodes, &mut clients, false);
+        // `poll_with_resend` is required for the case that the group leader doesn't expect the
+        // request (thinking there is conflict operation), and have to accumulate on another route.
+        event_count += poll::nodes_and_clients_with_resend(&mut nodes, &mut clients);
         trace!("Processed {} events.", event_count);
 
         while let Ok(event) = clients[0].try_recv() {


### PR DESCRIPTION
Remove custom mock crust handling for rate exceeded events which is handled by routing.