### PR TITLE
Add example config files for local networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # safe_vault
 
+An autonomous network capable of data storage/publishing/sharing as well as computation, value transfer (cryptocurrency support), and more.
+See the documentation for a more detailed description of the operations involved in data storage.
+
 **Maintainer:** Andreas Fackler (andreas.fackler@maidsafe.net)
 
 |Crate|Documentation|Linux/OS X|Windows|Issues|
@@ -9,9 +12,46 @@
 | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
 
-## Overview
+## Development
 
-An autonomous network capable of data storage/publishing/sharing as well as computation, value transfer (crypto currency support) and more. See the documentation for a more detailed description of the operations involved in data storage.
+1. Prerequisites:
+
+    * [Git](https://git-scm.com/downloads) for version control
+    * [Cargo](https://www.rustup.rs/) for Rust
+
+2. Clone this GitHub repository:
+
+    ```bash
+    git clone https://github.com/maidsafe/safe_vault.git
+    ```
+
+3. Build the app for production (this may take several minutes):
+
+    ``` bash
+    cd safe_vault
+    cargo build --release
+    ```
+
+    This should produce the SAFE Vault binary in the folder `safe_vault/target/release`.
+    It will be called either `safe_vault` or `safe_vault.exe` depending on your platform.
+
+4. In the same folder as above (`safe_vault/target/release`), add a few config files as described [here](https://forum.safedev.org/t/how-to-run-a-local-test-network/842).
+
+### Testing
+
+To run tests locally:
+
+```bash
+cargo test
+```
+
+## Further Help
+
+You can discuss development-related questions on the [SAFE Dev Forum](https://forum.safedev.org/).
+Here are some good posts to get started:
+
+- [How to run a local test network](https://forum.safedev.org/t/how-to-run-a-local-test-network/842)
+- [How to develop for the SAFE Network](https://forum.safedev.org/t/how-to-develop-for-the-safe-network-draft/843)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# safe_vault
+# SAFE Vault
 
 An autonomous network capable of data storage/publishing/sharing as well as computation, value transfer (cryptocurrency support), and more.
 See the documentation for a more detailed description of the operations involved in data storage.
@@ -27,7 +27,7 @@ See the documentation for a more detailed description of the operations involved
 
 3. Build the app for production (this may take several minutes):
 
-    ``` bash
+    ```bash
     cd safe_vault
     cargo build --release
     ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,40 @@ See the documentation for a more detailed description of the operations involved
     This should produce the SAFE Vault binary in the folder `safe_vault/target/release`.
     It will be called either `safe_vault` or `safe_vault.exe` depending on your platform.
 
-4. In the same folder as above (`safe_vault/target/release`), add a few config files as described [here](https://forum.safedev.org/t/how-to-run-a-local-test-network/842).
+### Running a local network
+
+#### Configuring your vaults
+
+1. In the same folder as above (`safe_vault/target/release`), add a few config files as described [here](https://forum.safedev.org/t/how-to-run-a-local-test-network/842).
+
+    To use some default configs that should work out of the box:
+
+    ```bash
+    cp example-configs/*.config target/release/
+    ```
+
+2. Start your first vault:
+
+    ```bash
+    ./target/release/safe_vault --first
+    ```
+
+3. Start any additional vaults in separate terminals (you need to run at least `min_section_size` vaults based on your config):
+
+    ```bash
+    ./target/release/safe_vault
+    ```
+
+#### Configuring your browser
+
+1. You'll need to use similar configs for your SAFE Browser if you want to connect to your local vaults, e.g. if building on Linux:
+
+    ```bash
+    cp example-configs/safe_vault.crust.config ../safe_browser/dist/linux-unpacked/safe-browser.crust.config
+    cp example-configs/safe_vault.routing.config ../safe_browser/dist/linux-unpacked/safe-browser.routing.config
+    ```
+
+2. Open your SAFE Browser and create an account!
 
 ### Testing
 

--- a/example-configs/safe_vault.crust.config
+++ b/example-configs/safe_vault.crust.config
@@ -1,0 +1,7 @@
+{
+  "hard_coded_contacts": [],
+  "force_acceptor_port_in_ext_ep": false,
+  "dev": {
+    "disable_external_reachability_requirement": true
+  }
+}

--- a/example-configs/safe_vault.routing.config
+++ b/example-configs/safe_vault.routing.config
@@ -1,0 +1,8 @@
+{
+  "dev": {
+    "allow_multiple_lan_nodes": true,
+    "disable_client_rate_limiter": true,
+    "disable_resource_proof": true,
+    "min_section_size": 2
+  }
+}

--- a/example-configs/safe_vault.vault.config
+++ b/example-configs/safe_vault.vault.config
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "disable_mutation_limit": true
+  }
+}


### PR DESCRIPTION
> :warning: This PR is based on https://github.com/maidsafe/safe_vault/pull/650, and shouldn't be merged until after rebasing. See the real diff: https://github.com/cooperka/safe_vault/compare/readme-tweaks...example-configs

### Motivation

Developing and testing locally is important to be able to do, but I had a bit of confusion setting up a local vault/test network even while following the [guide](https://forum.safedev.org/t/how-to-run-a-local-test-network/842), so I wanted to add more context to the README with some example configs that can be copied and work out of the box.

### Changes

- Added working example config files under `example-configs`
- Added a section to the README explaining how to use these configs to run a local network

View the updated README visually: https://github.com/cooperka/safe_vault/blob/example-configs/README.md