### PR TITLE
fix/imports: remove unused 'log' imports

### DIFF
--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -13,7 +13,7 @@
 mod tests;
 
 use hex::{self, FromHex};
-use log::{info, log};
+use log::info;
 use maidsafe_utilities::serialisation::{self, SerialisationError};
 use quick_error::quick_error;
 use serde::de::DeserializeOwned;

--- a/src/personas/data_manager/cache.rs
+++ b/src/personas/data_manager/cache.rs
@@ -10,7 +10,7 @@ use super::data::{DataId, ImmutableDataId, MutableDataId};
 use super::mutation::{self, Mutation};
 use super::STATUS_LOG_INTERVAL;
 use crate::utils::{self, HashMap, HashSet, Instant, SecureHash};
-use log::{info, log};
+use log::info;
 use maidsafe_utilities::serialisation::serialised_size;
 use routing::{
     Authority, MessageId, MutableData, RoutingTable, Value, XorName, MAX_MUTABLE_DATA_ENTRIES,

--- a/src/personas/data_manager/mod.rs
+++ b/src/personas/data_manager/mod.rs
@@ -21,7 +21,7 @@ use crate::utils::{self, HashMap, HashSet, Instant};
 use crate::vault::Refresh as VaultRefresh;
 use crate::vault::RoutingNode;
 use accumulator::Accumulator;
-use log::{error, info, log, trace, warn};
+use log::{error, info, trace, warn};
 use maidsafe_utilities::serialisation;
 #[cfg(feature = "use-mock-crypto")]
 use routing::mock_crypto::rust_sodium;

--- a/src/personas/maid_manager/mod.rs
+++ b/src/personas/maid_manager/mod.rs
@@ -21,7 +21,7 @@ use crate::utils::{self, HashMap};
 use crate::vault::Refresh as VaultRefresh;
 use crate::vault::RoutingNode;
 use crate::TYPE_TAG_INVITE;
-use log::{debug, error, info, log, trace};
+use log::{debug, error, info, trace};
 use lru_time_cache::LruCache;
 use maidsafe_utilities::serialisation;
 #[cfg(feature = "use-mock-crypto")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@
 use self::rust_sodium::crypto::sign;
 #[cfg(any(test, feature = "use-mock-crust", feature = "use-mock-routing"))]
 pub use fake_clock::FakeClock as Instant;
-use log::{error, log};
+use log::error;
 use maidsafe_utilities::serialisation;
 #[cfg(feature = "use-mock-crypto")]
 use routing::mock_crypto::rust_sodium;

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -21,7 +21,7 @@ use crate::mock_routing::NodeBuilder;
 use crate::personas::data_manager::DataId;
 use crate::personas::data_manager::{self, DataManager};
 use crate::personas::maid_manager::{self, MaidManager};
-use log::{debug, log, warn};
+use log::{debug, warn};
 use maidsafe_utilities::serialisation;
 #[cfg(feature = "use-mock-crypto")]
 use routing::mock_crypto::rust_sodium;


### PR DESCRIPTION
After updating Rust (and so cargo) to v1.32.0, I was trying to build safe_vault, but this latest version is flagging 6 errors with an unused import: 'log'. Therefore I will remove this unused import in the 6 locations, which I have confirmed allows me to build.