### PR TITLE
Get published and unpublished immutable data

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -23,4 +23,9 @@ pub(crate) enum Action {
         response: Response,
         message_id: MessageId,
     },
+    ForwardResponseToClient {
+        sender: XorName,
+        response: Response,
+        message_id: MessageId,
+    },
 }

--- a/src/destination_elder.rs
+++ b/src/destination_elder.rs
@@ -446,12 +446,15 @@ impl DestinationElder {
 
     fn handle_get_idata_resp(
         &mut self,
-        _sender: XorName,
-        _result: NdResult<IDataKind>,
-        _message_id: MessageId,
+        sender: XorName,
+        result: NdResult<IDataKind>,
+        message_id: MessageId,
     ) -> Option<Action> {
-        // TODO - For phase 1 this is unused.
-        unimplemented!()
+        Some(Action::ForwardResponseToClient {
+            sender,
+            response: Response::GetIData(result),
+            message_id,
+        })
     }
 
     fn get_idata(&self, address: IDataAddress, message_id: MessageId) -> Option<Action> {

--- a/src/destination_elder.rs
+++ b/src/destination_elder.rs
@@ -15,7 +15,10 @@ use crate::{
 };
 use log::{error, trace, warn};
 use pickledb::PickleDb;
-use safe_nd::{IDataKind, MessageId, NodePublicId, Request, Response, Result as NdResult, XorName};
+use safe_nd::{
+    IDataAddress, IDataKind, MessageId, NodePublicId, Request, Response, Result as NdResult,
+    XorName,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
@@ -114,7 +117,7 @@ impl DestinationElder {
             // ===== Immutable Data =====
             //
             PutIData(kind) => self.handle_put_idata_req(src, kind, message_id),
-            GetIData(address) => unimplemented!(),
+            GetIData(address) => self.handle_get_idata_req(src, address, message_id),
             DeleteUnpubIData(address) => unimplemented!(),
             //
             // ===== Mutable Data =====
@@ -233,7 +236,7 @@ impl DestinationElder {
             // ===== Immutable Data =====
             //
             PutIData(result) => self.handle_put_idata_resp(src, result, message_id),
-            GetIData(result) => unimplemented!(),
+            GetIData(result) => self.handle_get_idata_resp(src, result, message_id),
             DeleteUnpubIData(result) => unimplemented!(),
             //
             // ===== Mutable Data =====
@@ -395,6 +398,78 @@ impl DestinationElder {
     // Returns an iterator over all of our section's elders' names, sorted by closest to `target`.
     fn elders_sorted(&self, _target: &XorName) -> impl Iterator<Item = &XorName> {
         iter::once(self.id.name())
+    }
+
+    fn handle_get_idata_req(
+        &mut self,
+        src: XorName,
+        address: IDataAddress,
+        message_id: MessageId,
+    ) -> Option<Action> {
+        if &src == address.name() {
+            // The message was sent by the dst elders to us as the one who is supposed to store the
+            // chunk. See the sent Get request below.
+            self.get_idata(address, message_id)
+        } else {
+            // We're acting as dst elder, received request from src elders
+            let metadata = if let Some(metadata) = self
+                .immutable_metadata
+                .get::<ChunkMetadata>(&address.to_db_key())
+            {
+                metadata
+            } else {
+                warn!("{}: Failed to get metadata from DB: {:?}", self, address);
+                return None;
+            };
+
+            // TODO - Should we try the 3 holders in serial checking for responses between each
+            //        send or simply broadcast and get the first response?
+            // We just get the first for now. In phase 1 this is ourself anyway.
+            let metadata_holder = if let Some(metadata_holder) = metadata.holders.first() {
+                metadata_holder
+            } else {
+                warn!(
+                    "{}: Failed to get location from metadata holders: {:?}",
+                    self, metadata.holders
+                );
+                return None;
+            };
+
+            if metadata_holder == self.id.name() {
+                self.get_idata(address, message_id)
+            } else {
+                // TODO - Send Get request to adult (or elder occasionally) with src = data.
+                None
+            }
+        }
+    }
+
+    fn handle_get_idata_resp(
+        &mut self,
+        _sender: XorName,
+        _result: NdResult<IDataKind>,
+        _message_id: MessageId,
+    ) -> Option<Action> {
+        // TODO - For phase 1 this is unused.
+        unimplemented!()
+    }
+
+    fn get_idata(&self, address: IDataAddress, message_id: MessageId) -> Option<Action> {
+        let result = self
+            .immutable_chunks
+            .get(&address)
+            .map_err(|error| error.to_string().into())
+            .map(|kind| {
+                if !kind.published() {
+                    // TODO - Verify ownership
+                }
+                kind
+            });
+        Some(Action::RespondToOurDstElders {
+            sender: *self.id.name(),
+            response: Response::GetIData(result),
+            message_id,
+        })
     }
 }
 

--- a/src/source_elder.rs
+++ b/src/source_elder.rs
@@ -426,7 +426,7 @@ impl SourceElder {
         }
     }
 
-    pub fn _handle_node_response(
+    pub fn handle_node_response(
         &mut self,
         dst_elders: XorName,
         src_elders: XorName,
@@ -449,7 +449,11 @@ impl SourceElder {
             // ===== Immutable Data =====
             //
             PutIData(result) => unimplemented!(),
-            GetIData(result) => unimplemented!(),
+            GetIData(ref result) => {
+                let _msg = utils::serialise(&response);
+                // TODO - Send this msg back to the client
+                None
+            }
             DeleteUnpubIData(result) => unimplemented!(),
             //
             // ===== Mutable Data =====

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -179,6 +179,17 @@ impl Vault {
                 self.destination_elder_mut()?
                     .handle_response(sender, response, message_id)
             }
+            ForwardResponseToClient {
+                sender,
+                response,
+                message_id,
+            } => {
+                let dst_elders = sender;
+                // TODO - simplification during phase 1
+                let src_elders = *self.id.public_id().name();
+                self.source_elder_mut()?
+                    .handle_node_response(dst_elders, src_elders, response, message_id)
+            }
         }
     }
 


### PR DESCRIPTION
Get immutable data

- Mark clients as registered/unregistered when connecting
- Handle GetIData RFC for both published and unpublished immutable data

Remains to be implemented

- Check permissions for unpublished immutable data
- ~Return to source elders~ and then client
- ~Return failure response in source elder to client~

Part of #691  