### PR TITLE
Implement delete unpublished immutable data response

### DIFF
--- a/src/destination_elder.rs
+++ b/src/destination_elder.rs
@@ -20,7 +20,7 @@ use crate::{
     Result, ToDbKey,
 };
 use idata_op::{IDataOp, OpType};
-use log::{error, trace, warn};
+use log::{error, info, trace, warn};
 use pickledb::PickleDb;
 use safe_nd::{
     Error as NdError, IData, IDataAddress, LoginPacket, MessageId, NodePublicId, PublicId, Request,
@@ -747,6 +747,11 @@ impl DestinationElder {
         message_id: MessageId,
     ) -> Option<Action> {
         let result = if self.immutable_chunks.has(kind.address()) {
+            info!(
+                "{}: Immutable chunk already exists, not storing: {:?}",
+                self,
+                kind.address()
+            );
             Ok(())
         } else {
             self.immutable_chunks

--- a/src/source_elder.rs
+++ b/src/source_elder.rs
@@ -246,11 +246,11 @@ impl SourceElder {
                     self.send_response_to_client(
                         &client.public_id,
                         message_id,
-                        // TODO: consider changing this error
                         Response::GetIData(Err(NdError::InvalidOperation)),
                     );
                     return None;
                 }
+                self.has_signature(&client.public_id, &request, &message_id, &signature)?;
                 if client.has_balance {
                     Some(Action::ForwardClientRequest(Rpc::Request {
                         requester: client.public_id.clone(),


### PR DESCRIPTION
Part of #692

The first commit implements the delete response, and then the other commits are purely grouping methods together. So it's probably easier to review by looking at each commit separately.