### PR TITLE
chore/all: refactored LoginPacket flows

### DIFF
--- a/src/adult.rs
+++ b/src/adult.rs
@@ -27,13 +27,8 @@ impl Adult {
         max_capacity: u64,
         init_mode: Init,
     ) -> Result<Self> {
-        let total_used_space = Rc::new(RefCell::new(0));
-        let _immutable_chunks = ImmutableChunkStore::new(
-            root_dir,
-            max_capacity,
-            Rc::clone(&total_used_space),
-            init_mode,
-        )?;
+        let _immutable_chunks =
+            ImmutableChunkStore::new(root_dir, max_capacity, Rc::new(RefCell::new(0)), init_mode)?;
         Ok(Self {
             _id: id,
             _immutable_chunks,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -69,6 +69,8 @@ pub(crate) fn client(public_id: &PublicId) -> Option<&ClientPublicId> {
     }
 }
 
+/// Returns the client's or app's public key if `public_id` represents a Client or App respectively,
+/// or None if it represents a Node.
 pub(crate) fn own_key(public_id: &PublicId) -> Option<&PublicKey> {
     match public_id {
         PublicId::Node(_) => None,
@@ -130,12 +132,12 @@ pub(crate) fn dst_elders_address(request: &Request) -> Option<&XorName> {
             // ref new_balance_owner,
             ..
         } => None, // Some(XorName::from(new_balance_owner)),
-        CreateLoginPacket(account_data) => Some(account_data.destination()),
+        CreateLoginPacket(login_packet) => Some(login_packet.destination()),
         CreateLoginPacketFor {
             new_login_packet,
             ..
         } => Some(new_login_packet.destination()),
-        UpdateLoginPacket(account_data) => Some(account_data.destination()),
+        UpdateLoginPacket(login_packet) => Some(login_packet.destination()),
         GetLoginPacket(ref name) => Some(name),
         GetBalance
         | ListAuthKeysAndVersion


### PR DESCRIPTION
This changes the handler for login packets from `DestinationElder` to `SourceElder`.

It meant having `SourceElder` updated to handle Vault-level requests, since the flow for `CreateLoginPacket` involves sending from the client's elders to the elders of `login_packet.destination()`.