### PR TITLE
feat/all: use try_from in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,8 +749,8 @@ dependencies = [
 
 [[package]]
 name = "quic-p2p"
-version = "0.1.1"
-source = "git+https://github.com/maidsafe/quic-p2p?rev=d43460ae#d43460aedae3be78254b3a74c965af6c4d97c580"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1093,7 +1093,7 @@ dependencies = [
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pickledb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quic-p2p 0.1.1 (git+https://github.com/maidsafe/quic-p2p?rev=d43460ae)",
+ "quic-p2p 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1747,7 +1747,7 @@ dependencies = [
 "checksum pem 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2ae096568d61688cd1d419ca9815c94475d7b4622b1834d6e068e5bb2eb3d2"
 "checksum pickledb 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f84c239b2c2dc17025deda2d513de8218f1afd9ec7c34de45797ab35cf97d8a0"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum quic-p2p 0.1.1 (git+https://github.com/maidsafe/quic-p2p?rev=d43460ae)" = "<none>"
+"checksum quic-p2p 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9ceea6ff2622f92de8f2506a17d0e8995bda3621ce9c7ff557d982a3eae59"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quinn 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f79b799f97a3f97a69ab888bc92124fcdac3c6654ee5d46952f94fadd6a06d9"
 "checksum quinn-proto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5aeb6dc5d670066a6c90a666139f92d95f73b4ca8883d80e33b0693ef103f65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,20 @@ bincode = "=1.1.4"
 bytes = { version = "~0.4.12", features = ["serde"] }
 crossbeam-channel = "~0.3.8"
 directories = "~2.0.1"
-env_logger = "~0.6.1"
+env_logger = "~0.6.2"
 fxhash = { version = "~0.2.1", optional = true }
 hex = "~0.3.2"
 hex_fmt = { version = "~0.3.0", optional = true }
 lazy_static = "~1.3.0"
-log = "~0.4.6"
+log = "~0.4.7"
 pickledb = "~0.4.0"
-quic-p2p = { version = "~0.1.1", git = "https://github.com/maidsafe/quic-p2p", rev = "d43460ae", optional = true }
+quic-p2p = { version = "~0.2.0", optional = true }
 quick-error = "~1.2.2"
 rand = "~0.6.5"
 safe-nd = { version = "~0.1.0", git = "https://github.com/maidsafe/safe-nd" }
-serde = { version = "~1.0.93", features = ["derive"] }
-serde_json = "~1.0.39"
-structopt = "~0.2.16"
+serde = { version = "~1.0.97", features = ["derive"] }
+serde_json = "~1.0.40"
+structopt = "~0.2.18"
 tiny-keccak = "~1.5.0"
 unwrap = "~1.2.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,5 +87,6 @@ pub use crate::{
     config_handler::Config,
     error::{Error, Result},
     source_elder::COST_OF_PUT,
+    utils::to_error_response,
     vault::Vault,
 };

--- a/src/mock/quic_p2p/mod.rs
+++ b/src/mock/quic_p2p/mod.rs
@@ -94,7 +94,7 @@ impl QuicP2p {
     /// If the peer is not connected, it will attempt to connect to it first
     /// and then send the message. This can be called multiple times while the peer is still being
     /// connected to - all the sends will be buffered until the peer is connected to.
-    pub fn send(&mut self, peer: Peer, msg: Bytes) {
+    pub fn send(&mut self, peer: Peer, msg: Bytes, _token: u64) {
         self.inner.borrow_mut().send(peer.peer_addr(), msg)
     }
 

--- a/src/mock/quic_p2p/tests.rs
+++ b/src/mock/quic_p2p/tests.rs
@@ -425,7 +425,7 @@ impl Agent {
     }
 
     fn send(&mut self, dst_addr: SocketAddr, msg: Bytes) {
-        self.inner.send(Peer::node(dst_addr), msg)
+        self.inner.send(Peer::node(dst_addr), msg, 0)
     }
 
     fn addr(&self) -> SocketAddr {

--- a/src/source_elder.rs
+++ b/src/source_elder.rs
@@ -1047,7 +1047,7 @@ impl SourceElder {
     fn send<T: Serialize>(&mut self, recipient: Peer, msg: &T) {
         let msg = utils::serialise(msg);
         let msg = Bytes::from(msg);
-        self.quic_p2p.send(recipient, msg)
+        self.quic_p2p.send(recipient, msg, 0)
     }
 
     fn send_response_to_client(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -145,8 +145,8 @@ pub(crate) fn dst_elders_address(request: &Request) -> Option<&XorName> {
     }
 }
 
-// Create an error response for the given request.
-pub(crate) fn to_error_response(request: &Request, error: NdError) -> Response {
+/// Create an error response for the given request.
+pub fn to_error_response(request: &Request, error: NdError) -> Response {
     match request {
         Request::PutIData(_)
         | Request::DeleteUnpubIData(_)


### PR DESCRIPTION
This also updates quic-p2p, but the mock's behaviour hasn't been changed to reflect the real quic-p2p behaviour regarding the new `Token` being passed in `send()`.