### PR TITLE
Build and Release in Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.bk
 *.rsproj
 tags*
+artifacts/
 build/
 build-tests/
 target/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,5 @@ jobs:
     - script: scripts/tests --verbose
       env: CACHE_NAME=tests_linux
       os: linux
-    - script: scripts/tests --verbose
-      env: CACHE_NAME=tests_osx
-      os: osx
 before_cache:
   - cargo prune

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,7 +10,11 @@ RUN addgroup --gid 1001 maidsafe && \
 # We could perhaps put this into a base container at a later stage.
 RUN USER=maidsafe && \
     GROUP=maidsafe && \
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    echo "06b3e053be5aaccc91dd5a45faf2356f  fixuid-0.4-linux-amd64.tar.gz" > fixuid-0.4-linux-amd64.tar.gz.md5 && \
+    curl -OSsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz && \
+    md5sum -c fixuid-0.4-linux-amd64.tar.gz.md5 && \
+    tar -C /usr/local/bin -xzf fixuid-0.4-linux-amd64.tar.gz && \
+    rm fixuid-0.4-linux-amd64.tar.gz && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -34,6 +34,7 @@ USER maidsafe:maidsafe
 ENV CARGO_TARGET_DIR=/target YARN_GPG=no RUST_BACKTRACE=1
 
 RUN rustup component add rustfmt clippy && \
+    cargo build --release && \
     scripts/clippy --verbose && \
     scripts/tests --verbose
 ENTRYPOINT ["fixuid"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -21,6 +21,10 @@ RUN USER=maidsafe && \
     printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
 
 RUN apt-get update -y && \
+    apt-get install -y \
+        gcc \
+        musl-dev \
+        musl-tools && \
     mkdir /target && \
     chown maidsafe:maidsafe /target && \
     mkdir /usr/src/safe_vault && \
@@ -35,10 +39,8 @@ COPY . .
 # the tests write a file and you need permissions for that.
 RUN chown -R maidsafe:maidsafe /usr/src/safe_vault
 USER maidsafe:maidsafe
-ENV CARGO_TARGET_DIR=/target YARN_GPG=no RUST_BACKTRACE=1
-
+ENV CARGO_TARGET_DIR=/target RUST_BACKTRACE=1
 RUN rustup component add rustfmt clippy && \
-    cargo build --release && \
-    scripts/clippy --verbose && \
+    rustup target add x86_64-unknown-linux-musl && \
     scripts/tests --verbose
 ENTRYPOINT ["fixuid"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,39 @@
+FROM rust:latest
+
+RUN addgroup --gid 1001 maidsafe && \
+    adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
+    # The parent container sets this to the 'staff' group, which causes problems
+    # with reading code stored in Cargo's registry.
+    chgrp -R maidsafe /usr/local
+
+# Install fixuid for dealing with permissions issues with mounted volumes.
+# We could perhaps put this into a base container at a later stage.
+RUN USER=maidsafe && \
+    GROUP=maidsafe && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+RUN apt-get update -y && \
+    mkdir /target && \
+    chown maidsafe:maidsafe /target && \
+    mkdir /usr/src/safe_vault && \
+    chown maidsafe:maidsafe /usr/src/safe_vault && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/safe_vault
+COPY . .
+
+# During the build process, ownership of the source directory needs changed in advance because
+# the tests write a file and you need permissions for that.
+RUN chown -R maidsafe:maidsafe /usr/src/safe_vault
+USER maidsafe:maidsafe
+ENV CARGO_TARGET_DIR=/target YARN_GPG=no RUST_BACKTRACE=1
+
+RUN rustup component add rustfmt clippy && \
+    scripts/clippy --verbose && \
+    scripts/tests --verbose
+ENTRYPOINT ["fixuid"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,29 @@ stage("build & test") {
     }
 }
 
+stage('deploy') {
+    node('safe_vault') {
+        if (env.BRANCH_NAME == "master") {
+            checkout(scm)
+            sh("git fetch --tags --force")
+            retrieveBuildArtifacts()
+            if (versionChangeCommit()) {
+                version = sh(
+                    returnStdout: true,
+                    script: "grep '^version' < Cargo.toml | head -n 1 | awk '{ print \$3 }' | sed 's/\"//g'").trim()
+                packageArtifactsForDeploy(true)
+                createTag(version)
+                createGithubRelease(version)
+            } else {
+                packageArtifactsForDeploy(false)
+                uploadDeployArtifacts()
+            }
+        } else {
+            echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
+        }
+    }
+}
+
 def packageBuildArtifacts(os) {
     branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
     withEnv(["SAFE_VAULT_BRANCH=${branch}",
@@ -55,6 +78,70 @@ def uploadBuildArtifacts() {
                 bucket: "${params.ARTIFACTS_BUCKET}",
                 file: artifact,
                 workingDir: "${env.WORKSPACE}/artifacts",
+                acl: 'PublicRead')
+        }
+    }
+}
+
+def retrieveBuildArtifacts() {
+    branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
+    withEnv(["SAFE_VAULT_BRANCH=${branch}",
+             "SAFE_VAULT_BUILD_NUMBER=${env.BUILD_NUMBER}"]) {
+        sh("make retrieve-all-build-artifacts")
+    }
+}
+
+def versionChangeCommit() {
+    shortCommitHash = sh(
+        returnStdout: true,
+        script: "git log -n 1 --pretty=format:'%h'").trim()
+    message = sh(
+        returnStdout: true,
+        script: "git log --format=%B -n 1 ${shortCommitHash}").trim()
+    return message.startsWith("Version change")
+}
+
+def packageArtifactsForDeploy(isVersionCommit) {
+    if (isVersionCommit) {
+        sh("make package-version-artifacts-for-deploy")
+    } else {
+        sh("make package-commit_hash-artifacts-for-deploy")
+    }
+}
+
+def createTag(version) {
+    withCredentials(
+        [usernamePassword(
+            credentialsId: "github_maidsafe_qa_user_credentials",
+            usernameVariable: "GIT_USER",
+            passwordVariable: "GIT_PASSWORD")]) {
+        sh("git config --global user.name \$GIT_USER")
+        sh("git config --global user.email qa@maidsafe.net")
+        sh("git config credential.username \$GIT_USER")
+        sh("git config credential.helper '!f() { echo password=\$GIT_PASSWORD; }; f'")
+        sh("git tag -a ${version} -m 'Creating tag for ${version}'")
+        sh("GIT_ASKPASS=true git push origin --tags")
+    }
+}
+
+def createGithubRelease(version) {
+    withCredentials(
+        [usernamePassword(
+            credentialsId: "github_maidsafe_token_credentials",
+            usernameVariable: "GITHUB_USER",
+            passwordVariable: "GITHUB_TOKEN")]) {
+        sh("make deploy-github-release")
+    }
+}
+
+def uploadDeployArtifacts() {
+    withAWS(credentials: 'aws_jenkins_deploy_artifacts_user', region: 'eu-west-2') {
+        def artifacts = sh(returnStdout: true, script: 'ls -1 deploy').trim().split("\\r?\\n")
+        for (artifact in artifacts) {
+            s3Upload(
+                bucket: "${params.DEPLOY_BUCKET}",
+                file: artifact,
+                workingDir: "${env.WORKSPACE}/deploy",
                 acl: 'PublicRead')
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,6 @@ stage("build & test") {
         node("safe_vault") {
             checkout(scm)
             sh("make test")
-            packageBuildArtifacts("linux")
-            uploadBuildArtifacts()
         }
     },
     windows: {
@@ -36,6 +34,14 @@ stage("build & test") {
         node("safe_vault") {
             checkout(scm)
             sh("make clippy")
+        }
+    },
+    musl: {
+        node("safe_vault") {
+            checkout(scm)
+            sh("make musl")
+            packageBuildArtifacts("linux")
+            uploadBuildArtifacts()
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ stage('deploy') {
                 packageArtifactsForDeploy(true)
                 createTag(version)
                 createGithubRelease(version)
+                publishCrate()
             } else {
                 packageArtifactsForDeploy(false)
                 uploadDeployArtifacts()
@@ -131,6 +132,13 @@ def createGithubRelease(version) {
             usernameVariable: "GITHUB_USER",
             passwordVariable: "GITHUB_TOKEN")]) {
         sh("make deploy-github-release")
+    }
+}
+
+def publishCrate() {
+    withCredentials([string(
+        credentialsId: 'crates_io_token', variable: 'CRATES_IO_TOKEN')]) {
+        sh("make publish")
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,61 @@
+properties([
+    parameters([
+        string(name: "ARTIFACTS_BUCKET", defaultValue: "safe-jenkins-build-artifacts"),
+        string(name: "DEPLOY_BUCKET", defaultValue: "safe-vault")
+    ])
+])
+
+stage("build & test") {
+    parallel linux: {
+        node("safe_vault") {
+            checkout(scm)
+            sh("make test")
+            packageBuildArtifacts("linux")
+            uploadBuildArtifacts()
+        }
+    },
+    windows: {
+        node("windows") {
+            checkout(scm)
+            sh("make test")
+            packageBuildArtifacts("windows")
+            uploadBuildArtifacts()
+        }
+    },
+    macos: {
+        node("osx") {
+            checkout(scm)
+            sh("make test")
+            packageBuildArtifacts("macos")
+            uploadBuildArtifacts()
+        }
+    },
+    clippy: {
+        node("safe_vault") {
+            checkout(scm)
+            sh("make clippy")
+        }
+    }
+}
+
+def packageBuildArtifacts(os) {
+    branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
+    withEnv(["SAFE_VAULT_BRANCH=${branch}",
+             "SAFE_VAULT_BUILD_NUMBER=${env.BUILD_NUMBER}",
+             "SAFE_VAULT_BUILD_OS=${os}"]) {
+        sh("make package-build-artifacts")
+    }
+}
+
+def uploadBuildArtifacts() {
+    withAWS(credentials: 'aws_jenkins_build_artifacts_user', region: 'eu-west-2') {
+        def artifacts = sh(returnStdout: true, script: 'ls -1 artifacts').trim().split("\\r?\\n")
+        for (artifact in artifacts) {
+            s3Upload(
+                bucket: "${params.ARTIFACTS_BUCKET}",
+                file: artifact,
+                workingDir: "${env.WORKSPACE}/artifacts",
+                acl: 'PublicRead')
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+SHELL := /bin/bash
+USER_ID := $(shell id -u)
+GROUP_ID := $(shell id -g)
+UNAME_S := $(shell uname -s)
+PWD := $(shell echo $$PWD)
+UUID := $(shell uuidgen | sed 's/-//g')
+S3_BUCKET := safe-jenkins-build-artifacts
+GITHUB_REPO_OWNER := maidsafe
+GITHUB_REPO_NAME := safe-cli
+
+build-container:
+	rm -rf target/
+	docker rmi -f maidsafe/safe-vault-build:build
+	docker build -f Dockerfile.build -t maidsafe/safe-vault-build:build .
+
+push-container:
+	docker push maidsafe/safe-vault-build:build
+
+clippy:
+ifeq ($(UNAME_S),Linux)
+	docker run --name "safe-vault-build-${UUID}" \
+		-v "${PWD}":/usr/src/safe_vault:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-vault-build:build \
+		./scripts/clippy --verbose
+else
+	./scripts/clippy --verbose
+endif
+
+test:
+	rm -rf artifacts
+	mkdir artifacts
+ifeq ($(UNAME_S),Linux)
+	docker run --name "safe-vault-build-${UUID}" \
+		-v "${PWD}":/usr/src/safe_vault:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-vault-build:build \
+		./scripts/tests --verbose
+	docker cp "safe-vault-build-${UUID}":/target .
+	docker rm "safe-vault-build-${UUID}"
+else
+	./scripts/tests --verbose
+endif
+	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+SAFE_VAULT_VERSION := $(shell grep "^version" < Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
 USER_ID := $(shell id -u)
 GROUP_ID := $(shell id -g)
 UNAME_S := $(shell uname -s)
@@ -63,3 +64,80 @@ endif
 	tar -C artifacts -zcvf ${ARCHIVE_NAME} .
 	rm artifacts/**
 	mv ${ARCHIVE_NAME} artifacts
+
+retrieve-all-build-artifacts:
+ifndef SAFE_VAULT_BRANCH
+	@echo "A branch or PR reference must be provided."
+	@echo "Please set SAFE_VAULT_BRANCH to a valid branch or PR reference."
+	@exit 1
+endif
+ifndef SAFE_VAULT_BUILD_NUMBER
+	@echo "A build number must be supplied for build artifact packaging."
+	@echo "Please set SAFE_VAULT_BUILD_NUMBER to a valid build number."
+	@exit 1
+endif
+	rm -rf artifacts
+	mkdir -p artifacts/linux/release
+	mkdir -p artifacts/win/release
+	mkdir -p artifacts/macos/release
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-linux-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-windows-x86_64.tar.gz .
+	aws s3 cp --no-sign-request --region eu-west-2 s3://${S3_BUCKET}/${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-macos-x86_64.tar.gz .
+	tar -C artifacts/linux/release -xvf ${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-linux-x86_64.tar.gz
+	tar -C artifacts/win/release -xvf ${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-windows-x86_64.tar.gz
+	tar -C artifacts/macos/release -xvf ${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-macos-x86_64.tar.gz
+	rm ${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-linux-x86_64.tar.gz
+	rm ${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-windows-x86_64.tar.gz
+	rm ${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-macos-x86_64.tar.gz
+
+package-commit_hash-artifacts-for-deploy:
+	rm -f *.tar
+	rm -rf deploy
+	mkdir deploy
+	tar -C artifacts/linux/release -cvf safe_vault-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu.tar safe_vault
+	tar -C artifacts/win/release -cvf safe_vault-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu.tar safe_vault.exe
+	tar -C artifacts/macos/release -cvf safe_vault-$$(git rev-parse --short HEAD)-x86_64-apple-darwin.tar safe_vault
+	mv safe_vault-$$(git rev-parse --short HEAD)-x86_64-unknown-linux-gnu.tar deploy
+	mv safe_vault-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu.tar deploy
+	mv safe_vault-$$(git rev-parse --short HEAD)-x86_64-apple-darwin.tar deploy
+
+package-version-artifacts-for-deploy:
+	rm -f *.tar
+	rm -rf deploy
+	mkdir deploy
+	tar -C artifacts/linux/release -cvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-gnu.tar safe_vault
+	tar -C artifacts/win/release -cvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar safe_vault.exe
+	tar -C artifacts/macos/release -cvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar safe_vault
+	mv safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-gnu.tar deploy
+	mv safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar deploy
+	mv safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar deploy
+
+deploy-github-release:
+ifndef GITHUB_TOKEN
+	@echo "Please set GITHUB_TOKEN to the API token for a user who can create releases."
+	@exit 1
+endif
+	github-release release \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_VAULT_VERSION} \
+		--name "safe-vault" \
+		--description "Command line interface for the SAFE Network";
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_VAULT_VERSION} \
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-gnu.tar" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-gnu.tar;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_VAULT_VERSION} \
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar;
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_VAULT_VERSION} \
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar;

--- a/Makefile
+++ b/Makefile
@@ -155,3 +155,19 @@ endif
 		-u ${USER_ID}:${GROUP_ID} \
 		maidsafe/safe-vault-build:build \
 		/bin/bash -c "cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"
+
+retrieve-cache:
+ifndef SAFE_VAULT_BRANCH
+	@echo "A branch reference must be provided."
+	@echo "Please set SAFE_VAULT_BRANCH to a valid branch reference."
+	@exit 1
+endif
+ifeq ($(OS),Windows_NT)
+	aws s3 cp \
+		--no-sign-request \
+		--region eu-west-2 \
+		s3://${S3_BUCKET}/safe_vault-${SAFE_VAULT_BRANCH}-windows-cache.tar.gz .
+	mkdir target
+	tar -C target -xvf safe_vault-${SAFE_VAULT_BRANCH}-windows-cache.tar.gz
+	rm safe_vault-${SAFE_VAULT_BRANCH}-windows-cache.tar.gz
+endif

--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,14 @@ endif
 		--tag ${SAFE_VAULT_VERSION} \
 		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar" \
 		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar;
+
+publish:
+ifndef CRATES_IO_TOKEN
+	@echo "A login token for crates.io must be provided."
+	@exit 1
+endif
+	rm -rf artifacts
+	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-vault-build:build \
+		/bin/bash -c "cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PWD := $(shell echo $$PWD)
 UUID := $(shell uuidgen | sed 's/-//g')
 S3_BUCKET := safe-jenkins-build-artifacts
 GITHUB_REPO_OWNER := maidsafe
-GITHUB_REPO_NAME := safe-cli
+GITHUB_REPO_NAME := safe_vault
 
 build-container:
 	rm -rf target/
@@ -42,3 +42,24 @@ else
 	./scripts/tests --verbose
 endif
 	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
+
+package-build-artifacts:
+ifndef SAFE_VAULT_BRANCH
+	@echo "A branch or PR reference must be provided."
+	@echo "Please set SAFE_VAULT_BRANCH to a valid branch or PR reference."
+	@exit 1
+endif
+ifndef SAFE_VAULT_BUILD_NUMBER
+	@echo "A build number must be supplied for build artifact packaging."
+	@echo "Please set SAFE_VAULT_BUILD_NUMBER to a valid build number."
+	@exit 1
+endif
+ifndef SAFE_VAULT_BUILD_OS
+	@echo "A value must be supplied for SAFE_VAULT_BUILD_OS."
+	@echo "Valid values are 'linux' or 'windows' or 'macos'."
+	@exit 1
+endif
+	$(eval ARCHIVE_NAME := ${SAFE_VAULT_BRANCH}-${SAFE_VAULT_BUILD_NUMBER}-safe_vault-${SAFE_VAULT_BUILD_OS}-x86_64.tar.gz)
+	tar -C artifacts -zcvf ${ARCHIVE_NAME} .
+	rm artifacts/**
+	mv ${ARCHIVE_NAME} artifacts

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,13 @@ ifeq ($(UNAME_S),Linux)
 		-v "${PWD}":/usr/src/safe_vault:Z \
 		-u ${USER_ID}:${GROUP_ID} \
 		maidsafe/safe-vault-build:build \
-		./scripts/tests --verbose
+		/bin/bash -c "cargo build --release && ./scripts/tests --verbose"
 	docker cp "safe-vault-build-${UUID}":/target .
 	docker rm "safe-vault-build-${UUID}"
 else
+	# The explicit `cargo build` is because the test script does not actually
+	# produce a binary to distribute.
+	cargo build --release
 	./scripts/tests --verbose
 endif
 	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;


### PR DESCRIPTION
Adds a build and release process in Jenkins.

## Build & Test Stage

* In parallel:
    - Run clippy
    - Build and test on Linux
    - Build with musl on Linux
    - Build and test on macOS
    - Build and test on Windows
* Upload build artifacts

The reason for having a separate path for building with musl is because we can't run the tests against a musl version: they pull in dependencies that result in a linker failure related to libc. However, I had a conversation with Nikita and he said if `cargo build --release --target x86_64-unknown-linux-musl` works, then we should be able to distribute that just fine.

## Deployment Stage

* Clone the code with the tags fetched (not done by default)
* Retrieve build artifacts from first stage
* If the commit message is a version change:
    - Get the version number
    - Package the artifacts with version number in file name
    - Create a tag for this version
    - Publish a GitHub release
    - Publish to crates.io
* Otherwise:
    - Package the artifacts with commit hash in file name
    - Upload the artifacts to the safe-vault S3 bucket

## Supporting Evidence

### Deployment without Version Change

[Build log](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_vault/detail/PR-782/4/pipeline)

Artifacts produced:
```
aws s3 ls s3://safe-vault | sort
2019-08-01 11:55:00    9226240 safe_vault-17bcf39-x86_64-apple-darwin.tar
2019-08-01 11:55:01   12400640 safe_vault-17bcf39-x86_64-unknown-linux-gnu.tar
2019-08-01 11:55:01   20428800 safe_vault-17bcf39-x86_64-pc-windows-gnu.tar
```

### Deployment with Version Change

[Build log](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_vault/detail/PR-782/13).

[Release](https://github.com/jacderida/safe_vault/releases/tag/0.18.1) on my fork.

Since you can't delete anything from crates.io, I wasn't able to run a real publish. However, I have tested the same code on a sample project:

* [Here](https://crates.io/crates/jenkins_sample_lib) are some crates that were uploaded.
* [Here](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-sandbox/detail/pipeline-sandbox/3/pipeline/) is the build that produced crate 0.0.3.
* [Here](https://github.com/maidsafe/jenkins_sample_lib/blob/42f98a4a9d2954d1e063808651b9dd90b4a38dd1/Jenkinsfile#L41) is the Jenkinsfile for the sample project

Cheers,

Chris
