### PR TITLE
Transaction flow

### DIFF
--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -294,12 +294,12 @@ impl ClientHandler {
                 destination,
                 amount,
                 transaction_id,
-            } => self.handle_transfer_coins(
+            } => self.handle_transfer_coins_client_req(
                 &client.public_id,
-                message_id,
                 destination,
                 amount,
                 transaction_id,
+                message_id,
             ),
             GetBalance => {
                 let balance = self
@@ -313,12 +313,12 @@ impl ClientHandler {
                 new_balance_owner,
                 amount,
                 transaction_id,
-            } => self.handle_create_balance(
+            } => self.handle_create_balance_client_req(
                 &client.public_id,
-                message_id,
                 new_balance_owner,
                 amount,
                 transaction_id,
+                message_id,
             ),
             //
             // ===== Login packets =====
@@ -754,6 +754,28 @@ impl ClientHandler {
                 new_login_packet,
                 message_id,
             ),
+            CreateBalance {
+                new_balance_owner,
+                amount,
+                transaction_id,
+            } => self.handle_create_balance_vault_req(
+                requester,
+                new_balance_owner,
+                amount,
+                transaction_id,
+                message_id,
+            ),
+            TransferCoins {
+                destination,
+                amount,
+                transaction_id,
+            } => self.handle_transfer_coins_vault_req(
+                requester,
+                destination,
+                amount,
+                transaction_id,
+                message_id,
+            ),
             PutIData(_)
             | GetIData(_)
             | DeleteUnpubIData(_)
@@ -789,12 +811,10 @@ impl ClientHandler {
             | SetADataOwner { .. }
             | AppendSeq { .. }
             | AppendUnseq(_)
-            | TransferCoins { .. }
             | GetBalance
             | ListAuthKeysAndVersion
             | InsAuthKey { .. }
             | DelAuthKey { .. }
-            | CreateBalance { .. }
             | UpdateLoginPacket { .. }
             | GetLoginPacket(..) => {
                 error!(
@@ -868,58 +888,159 @@ impl ClientHandler {
         }
     }
 
-    fn handle_create_balance(
+    fn handle_create_balance_client_req(
         &mut self,
-        public_id: &PublicId,
-        message_id: MessageId,
+        requester: &PublicId,
         owner_key: PublicKey,
         amount: Coins,
         transaction_id: TransactionId,
+        message_id: MessageId,
     ) -> Option<Action> {
-        let result = self
-            .withdraw_coins_for_transfer(public_id.name(), amount)
-            .and_then(|cost| {
-                self.create_balance(owner_key, amount).map_err(|error| {
-                    self.refund(public_id.name(), cost);
-                    error
-                })
-            })
-            .map(|_| Transaction {
-                id: transaction_id,
-                amount,
-            });
+        let result = match self.withdraw_coins_for_transfer(requester.name(), amount) {
+            Ok(()) => {
+                return Some(Action::ForwardClientRequest(Rpc::Request {
+                    request: Request::CreateBalance {
+                        new_balance_owner: owner_key,
+                        amount,
+                        transaction_id,
+                    },
+                    requester: requester.clone(),
+                    message_id,
+                }));
+            }
+            Err(error) => Err(error),
+        };
 
-        self.send_response_to_client(public_id, message_id, Response::Transaction(result));
+        self.send_response_to_client(requester, message_id, Response::Transaction(result));
         None
     }
 
-    fn handle_transfer_coins(
+    fn handle_create_balance_vault_req(
         &mut self,
-        public_id: &PublicId,
+        requester: PublicId,
+        owner_key: PublicKey,
+        amount: Coins,
+        transaction_id: TransactionId,
         message_id: MessageId,
+    ) -> Option<Action> {
+        let rpc = match self.create_balance(owner_key, amount) {
+            Ok(()) => {
+                let destination = XorName::from(owner_key);
+                let transaction = Transaction {
+                    id: transaction_id,
+                    amount,
+                };
+                self.notify_destination_owners(&destination, transaction);
+                Rpc::Response {
+                    response: Response::Transaction(Ok(transaction)),
+                    requester,
+                    message_id,
+                }
+            }
+            Err(_) => {
+                // Send refund.
+                Rpc::Request {
+                    request: Request::TransferCoins {
+                        destination: *requester.name(),
+                        amount,
+                        transaction_id,
+                    },
+                    requester,
+                    message_id,
+                }
+            }
+        };
+
+        Some(Action::RespondToClientHandlers {
+            sender: *self.id.name(),
+            rpc,
+        })
+    }
+
+    fn handle_transfer_coins_client_req(
+        &mut self,
+        requester: &PublicId,
         destination: XorName,
         amount: Coins,
         transaction_id: TransactionId,
+        message_id: MessageId,
     ) -> Option<Action> {
-        let result = self
-            .withdraw_coins_for_transfer(public_id.name(), amount)
-            .and_then(|cost| {
-                self.deposit(&destination, amount).map_err(|error| {
-                    self.refund(public_id.name(), cost);
-                    error
-                })
-            })
-            .map(|_| Transaction {
-                id: transaction_id,
-                amount,
-            })
-            .map(|transaction| {
-                self.notify_destination_owners(&destination, transaction);
-                transaction
-            });
+        match self.withdraw_coins_for_transfer(requester.name(), amount) {
+            Ok(()) => Some(Action::ForwardClientRequest(Rpc::Request {
+                request: Request::TransferCoins {
+                    destination,
+                    amount,
+                    transaction_id,
+                },
+                requester: requester.clone(),
+                message_id,
+            })),
+            Err(error) => {
+                self.send_response_to_client(
+                    requester,
+                    message_id,
+                    Response::Transaction(Err(error)),
+                );
+                None
+            }
+        }
+    }
 
-        self.send_response_to_client(public_id, message_id, Response::Transaction(result));
-        None
+    fn handle_transfer_coins_vault_req(
+        &mut self,
+        requester: PublicId,
+        destination: XorName,
+        amount: Coins,
+        transaction_id: TransactionId,
+        message_id: MessageId,
+    ) -> Option<Action> {
+        let result = self.deposit(&destination, amount);
+
+        if *requester.name() == destination {
+            // This is a refund.
+            // TODO: we might want to send a response back to the client, but currently we don't
+            // know the reason for the refund. We should consider adding a `type` field to
+            // `Request::TransferCoins` with possible values: `Normal` and `Refund(Error)`.
+
+            if let Err(error) = result {
+                error!("{} Failed to refund {} coins: {:?}", self, amount, error);
+            }
+
+            return None;
+        }
+
+        let rpc = match result {
+            Ok(()) => {
+                let transaction = Transaction {
+                    id: transaction_id,
+                    amount,
+                };
+                self.notify_destination_owners(&destination, transaction);
+
+                Rpc::Response {
+                    response: Response::Transaction(Ok(transaction)),
+                    requester,
+                    message_id,
+                }
+            }
+            Err(_) => {
+                // Send refund
+                Rpc::Request {
+                    request: Request::TransferCoins {
+                        destination: *requester.name(),
+                        amount,
+                        transaction_id,
+                    },
+                    requester,
+                    message_id,
+                }
+            }
+        };
+
+        Some(Action::RespondToClientHandlers {
+            sender: *self.id.name(),
+            rpc,
+        })
     }
 
     fn notify_destination_owners(&mut self, destination: &XorName, transaction: Transaction) {
@@ -932,15 +1053,12 @@ impl ClientHandler {
         &mut self,
         balance_name: &XorName,
         amount: Coins,
-    ) -> Result<Coins, NdError> {
-        match self.withdraw(balance_name, amount) {
-            Ok(()) => Ok(amount),
-            Err(error) => {
-                // Note: in phase 1, we proceed even if there are insufficient funds.
-                trace!("{}: Unable to withdraw {} coins: {}", self, amount, error);
-                Ok(unwrap!(Coins::from_nano(0)))
-            }
-        }
+    ) -> Result<(), NdError> {
+        self.withdraw(balance_name, amount).or_else(|error| {
+            // Note: in phase 1, we proceed even if there are insufficient funds.
+            trace!("{}: Unable to withdraw {} coins: {}", self, amount, error);
+            Ok(())
+        })
     }
 
     fn create_balance(&mut self, owner_key: PublicKey, amount: Coins) -> Result<(), NdError> {
@@ -962,15 +1080,6 @@ impl ClientHandler {
                 client.has_balance = true;
             }
             Ok(())
-        }
-    }
-
-    fn refund(&mut self, balance_name: &XorName, amount: Coins) {
-        if let Err(error) = self.deposit(balance_name, amount) {
-            error!(
-                "{}: Failed to refund {} coins to balance of {:?}: {:?}.",
-                self, amount, balance_name, error
-            );
         }
     }
 

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -249,6 +249,14 @@ impl Vault {
                 | Rpc::Request {
                     request: Request::CreateLoginPacketFor { .. },
                     ..
+                }
+                | Rpc::Request {
+                    request: Request::CreateBalance { .. },
+                    ..
+                }
+                | Rpc::Request {
+                    request: Request::TransferCoins { .. },
+                    ..
                 } => self
                     .client_handler_mut()?
                     .handle_vault_rpc(requester_name, rpc),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -61,10 +61,10 @@ use safe_nd::{
     ADataPubPermissions, ADataUnpubPermissionSet, ADataUnpubPermissions, ADataUser, AppPermissions,
     AppendOnlyData, ClientFullId, Coins, EntryError, Error as NdError, IData, IDataAddress,
     LoginPacket, MData, MDataAction, MDataAddress, MDataKind, MDataPermissionSet,
-    MDataSeqEntryActions, MDataUnseqEntryActions, MDataValue, Message, MessageId, PubImmutableData,
-    PubSeqAppendOnlyData, PubUnseqAppendOnlyData, PublicKey, Request, Response, Result as NdResult,
-    SeqAppendOnly, SeqMutableData, Transaction, UnpubImmutableData, UnpubSeqAppendOnlyData,
-    UnpubUnseqAppendOnlyData, UnseqAppendOnly, UnseqMutableData, XorName,
+    MDataSeqEntryActions, MDataUnseqEntryActions, MDataValue, Message, MessageId, Notification,
+    PubImmutableData, PubSeqAppendOnlyData, PubUnseqAppendOnlyData, PublicKey, Request, Response,
+    Result as NdResult, SeqAppendOnly, SeqMutableData, Transaction, UnpubImmutableData,
+    UnpubSeqAppendOnlyData, UnpubUnseqAppendOnlyData, UnseqAppendOnly, UnseqMutableData, XorName,
 };
 use safe_vault::COST_OF_PUT;
 use std::collections::{BTreeMap, BTreeSet};
@@ -357,6 +357,84 @@ fn coin_operations() {
     let amount_b = unwrap!(Coins::from_nano(3));
     common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, amount_a);
     common::send_request_expect_ok(&mut env, &mut client_b, Request::GetBalance, amount_b);
+}
+
+#[test]
+fn create_balance_that_already_exists() {
+    let mut env = Environment::new();
+
+    let mut client_a = env.new_connected_client();
+    let mut client_b = env.new_connected_client();
+
+    common::create_balance(&mut env, &mut client_a, None, 10);
+    common::create_balance(&mut env, &mut client_a, Some(&mut client_b), 4);
+
+    let balance_a = unwrap!(Coins::from_nano(6));
+    let balance_b = unwrap!(Coins::from_nano(4));
+
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+    common::send_request_expect_ok(&mut env, &mut client_b, Request::GetBalance, balance_b);
+
+    // Attempt to create the balance for B again. The request fails and the coins are refunded.
+    let transaction_id = 2;
+    let amount = unwrap!(Coins::from_nano(2));
+    let _ = client_a.send_request(Request::CreateBalance {
+        new_balance_owner: *client_b.public_id().public_key(),
+        amount,
+        transaction_id,
+    });
+    env.poll();
+
+    // A receives notification about the refund.
+    let Notification(transaction) = client_a.expect_notification();
+    assert_eq!(transaction.id, transaction_id);
+    assert_eq!(transaction.amount, amount);
+
+    // A does not receive any response (TODO: this might change)
+    client_a.expect_no_new_message();
+
+    // A's balance is refunded.
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+
+    // B does not receive anything.
+    client_b.expect_no_new_message();
+}
+
+#[test]
+fn transfer_coins_to_balance_that_doesnt_exist() {
+    let mut env = Environment::new();
+
+    let mut client_a = env.new_connected_client();
+    let client_b = env.new_connected_client();
+
+    let balance_a = unwrap!(Coins::from_nano(10));
+    common::create_balance(&mut env, &mut client_a, None, balance_a);
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+
+    // Attempt transfer coins to B's balance which doesn't exist.  The request fails and the coins
+    // are refunded.
+    let transaction_id = 4;
+    let amount = unwrap!(Coins::from_nano(4));
+    let _ = client_a.send_request(Request::TransferCoins {
+        destination: *client_b.public_id().name(),
+        amount,
+        transaction_id,
+    });
+    env.poll();
+
+    // A receives notification about the refund.
+    let Notification(transaction) = client_a.expect_notification();
+    assert_eq!(transaction.id, transaction_id);
+    assert_eq!(transaction.amount, amount);
+
+    // A does not receive any response (TODO: this might change)
+    client_a.expect_no_new_message();
+
+    // A's balance is refunded.
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+
+    // B does not receive anything.
+    client_b.expect_no_new_message();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR implements proper flow for coin transfer operations (`CreateBalance` and `TransferCoins`). That is, the flow is now like this:

```
Client 
    ▼ (request)
source ClientHandler 
    ▼ (request)
destination ClientHandler
    ▼ (response)
source ClientHandler
    ▼ (response or notification)
Client
```

It also adds tests covering some failure scenarios around coin transfers.

Closes #751 