### PR TITLE
Refactor error type for insufficient permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safe-nd"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1602,7 +1602,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "self_update 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2547,7 +2547,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f271e3552cd835fa28c541c34a7e8fdd8cdff09d77fe4eb8f6c42e87a11b096e"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum safe-nd 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84f8ba486a60d14ec51a35462ecf4f5a56f51539a1ef2d5a578724ffe3e664f"
+"checksum safe-nd 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb177622a4b10632e2fc0b3967d13f0f3f432977359ba067eea2c49e375b6ad7"
 "checksum safemem 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e133ccc4f4d1cd4f89cc8a7ff618287d56dc7f638b8e38fc32c5fdcadc339dd5"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ pickledb = "~0.4.0"
 quic-p2p = { version = "~0.2.1", optional = true }
 quick-error = "~1.2.2"
 rand = "~0.6.5"
-safe-nd = "~0.2.1"
+safe-nd = "~0.3.0"
 self_update = "0.5.1"
 serde = { version = "~1.0.97", features = ["derive"] }
 serde_json = "~1.0.40"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -825,7 +825,7 @@ fn get_unpub_append_only_data() {
         &mut env,
         &mut other_client,
         Request::GetAData(address),
-        NdError::InvalidPermissions,
+        NdError::AccessDenied,
     );
 }
 
@@ -1327,9 +1327,7 @@ fn pub_append_only_data_put_permissions() {
             permissions: perms_1.clone(),
             permissions_index: 1,
         },
-        // TODO: InvalidPermissions because client B doesn't have any key avail. We should consider
-        // changing this behaviour to AccessDenied.
-        NdError::InvalidPermissions,
+        NdError::AccessDenied,
     );
 
     common::perform_mutation(
@@ -1430,9 +1428,7 @@ fn unpub_append_only_data_put_permissions() {
             permissions: perms_1.clone(),
             permissions_index: 1,
         },
-        // TODO: InvalidPermissions because client B doesn't have any key avail. We should consider
-        // changing this behaviour to AccessDenied.
-        NdError::InvalidPermissions,
+        NdError::AccessDenied,
     );
 
     common::perform_mutation(
@@ -1554,9 +1550,7 @@ fn append_only_data_put_owners() {
             owner: owner_1,
             owners_index: 1,
         },
-        // TODO - InvalidPermissions because client B doesn't have their key registered. Maybe we
-        //        should consider changing this.
-        NdError::InvalidPermissions,
+        NdError::AccessDenied,
     );
     common::perform_mutation(
         &mut env,


### PR DESCRIPTION
- update to safe-nd 0.3.0
- refactor tests to expect `AccessDenied` when an app has insufficient
permissions to access Adata