### PR TITLE
App coin operations

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -147,13 +147,14 @@ pub(crate) enum AuthorisationKind {
     GetPub,
     // Get request against unpublished data.
     GetUnpub,
+    // Request to get balance.
+    GetBalance,
     // Mutation request.
     Mut,
 }
 
 // Returns the type of authorisation needed for the given request.
 pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
-    use AuthorisationKind::*;
     use Request::*;
 
     match request {
@@ -177,8 +178,8 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | CreateLoginPacketFor { .. }
         | UpdateLoginPacket(_)
         | InsAuthKey { .. }
-        | DelAuthKey { .. } => Mut,
-        GetIData(IDataAddress::Pub(_)) => GetPub,
+        | DelAuthKey { .. } => AuthorisationKind::Mut,
+        GetIData(IDataAddress::Pub(_)) => AuthorisationKind::GetPub,
         GetIData(IDataAddress::Unpub(_))
         | GetMData(_)
         | GetMDataValue { .. }
@@ -190,8 +191,7 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | ListMDataPermissions(_)
         | ListMDataUserPermissions { .. }
         | GetLoginPacket(_)
-        | GetBalance
-        | ListAuthKeysAndVersion => GetUnpub,
+        | ListAuthKeysAndVersion => AuthorisationKind::GetUnpub,
         GetAData(address)
         | GetADataValue { address, .. }
         | GetADataShell { address, .. }
@@ -203,10 +203,11 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | GetUnpubADataUserPermissions { address, .. }
         | GetADataOwners { address, .. } => {
             if address.is_pub() {
-                GetPub
+                AuthorisationKind::GetPub
             } else {
-                GetUnpub
+                AuthorisationKind::GetUnpub
             }
         }
+        GetBalance => AuthorisationKind::GetBalance,
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -531,7 +531,7 @@ pub fn create_balance(
 
 pub fn transfer_coins(
     env: &mut Environment,
-    src_client: &mut TestClient,
+    src_client: &mut impl TestClientTrait,
     dst_client: &mut TestClient,
     amount: impl IntoCoins,
     transaction_id: TransactionId,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -514,8 +514,6 @@ fn coin_operations_by_app_with_insufficient_permissions() {
     );
     env.establish_connection(&mut app);
 
-    // FIXME: this currently fails.
-    /*
     // The attempt to get balance by the app fails.
     common::send_request_expect_err(
         &mut env,
@@ -523,7 +521,6 @@ fn coin_operations_by_app_with_insufficient_permissions() {
         Request::GetBalance,
         NdError::AccessDenied,
     );
-    */
 
     // The attempt to transfer some coins by the app fails.
     let destination: XorName = env.rng().gen();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -436,6 +436,113 @@ fn transfer_coins_to_balance_that_doesnt_exist() {
     client_b.expect_no_new_message();
 }
 
+#[test]
+fn coin_operations_by_app() {
+    let mut env = Environment::new();
+    let mut client_a = env.new_connected_client();
+
+    // Create initial balance.
+    common::create_balance(&mut env, &mut client_a, None, 10);
+
+    // Create an app with permission to transfer coins.
+    let mut app = env.new_disconnected_app(client_a.public_id().clone());
+    common::perform_mutation(
+        &mut env,
+        &mut client_a,
+        Request::InsAuthKey {
+            key: *app.public_id().public_key(),
+            version: 1,
+            permissions: AppPermissions {
+                transfer_coins: true,
+            },
+        },
+    );
+    env.establish_connection(&mut app);
+
+    // Check the balance by the app.
+    common::send_request_expect_ok(
+        &mut env,
+        &mut app,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(10)),
+    );
+
+    // Create the destination client with balance.
+    let mut client_b = env.new_connected_client();
+    common::create_balance(&mut env, &mut client_b, None, 0);
+
+    // App transfers some coins.
+    let transaction_id = 1;
+    common::transfer_coins(&mut env, &mut app, &mut client_b, 1, transaction_id);
+
+    // Check the coins did actually transfer.
+    common::send_request_expect_ok(
+        &mut env,
+        &mut client_a,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(9)),
+    );
+    common::send_request_expect_ok(
+        &mut env,
+        &mut client_b,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(1)),
+    );
+}
+
+#[test]
+fn coin_operations_by_app_with_insufficient_permissions() {
+    let mut env = Environment::new();
+    let mut owner = env.new_connected_client();
+
+    // Create initial balance.
+    let balance = unwrap!(Coins::from_nano(10));
+    common::create_balance(&mut env, &mut owner, None, balance);
+
+    // Create an app which does *not* have permission to transfer coins.
+    let mut app = env.new_disconnected_app(owner.public_id().clone());
+    common::perform_mutation(
+        &mut env,
+        &mut owner,
+        Request::InsAuthKey {
+            key: *app.public_id().public_key(),
+            version: 1,
+            permissions: AppPermissions {
+                transfer_coins: false,
+            },
+        },
+    );
+    env.establish_connection(&mut app);
+
+    // FIXME: this currently fails.
+    /*
+    // The attempt to get balance by the app fails.
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        Request::GetBalance,
+        NdError::AccessDenied,
+    );
+    */
+
+    // The attempt to transfer some coins by the app fails.
+    let destination: XorName = env.rng().gen();
+    let transaction_id = 1;
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        Request::TransferCoins {
+            destination,
+            amount: unwrap!(Coins::from_nano(1)),
+            transaction_id,
+        },
+        NdError::AccessDenied,
+    );
+
+    // The owners balance is unchanged.
+    common::send_request_expect_ok(&mut env, &mut owner, Request::GetBalance, balance);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Append-only data


### PR DESCRIPTION
- Add tests for coin operations by apps. 
- Add stricter permissions requirement for `GetBalance`

Closes #811 