### PR TITLE
fix/ci: filter merge commits in version check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ def retrieveBuildArtifacts() {
 def versionChangeCommit() {
     shortCommitHash = sh(
         returnStdout: true,
-        script: "git log -n 1 --pretty=format:'%h'").trim()
+        script: "git log -n 1 --no-merges --pretty=format:'%h'").trim()
     message = sh(
         returnStdout: true,
         script: "git log --format=%B -n 1 ${shortCommitHash}").trim()


### PR DESCRIPTION
We need to filter out the automated merge commits to correctly determine
whether this is a version change commit. This issue was discovered on
another repository.

You can see a PR for it for safe-nd:
https://github.com/maidsafe/safe-nd/pull/103