### PR TITLE
DeleteMData should be free of charge

### DIFF
--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -264,11 +264,11 @@ impl ClientHandler {
             //
             PutMData(chunk) => self.handle_put_mdata(client, chunk, message_id),
             MutateMDataEntries { .. }
-            | DeleteMData(..)
             | SetMDataUserPermissions { .. }
             | DelMDataUserPermissions { .. } => {
-                self.handle_mdata_mutation(request, client, message_id)
+                self.handle_mutate_mdata(request, client, message_id)
             }
+            DeleteMData(..) => self.handle_delete_mdata(request, client, message_id),
             GetMData(..)
             | GetMDataVersion(..)
             | GetMDataShell(..)
@@ -414,7 +414,7 @@ impl ClientHandler {
         }))
     }
 
-    fn handle_mdata_mutation(
+    fn handle_mutate_mdata(
         &mut self,
         request: Request,
         client: &ClientInfo,
@@ -429,6 +429,19 @@ impl ClientHandler {
             *COST_OF_PUT,
         )?;
 
+        Some(Action::ForwardClientRequest(Rpc::Request {
+            requester: client.public_id.clone(),
+            request,
+            message_id,
+        }))
+    }
+
+    fn handle_delete_mdata(
+        &mut self,
+        request: Request,
+        client: &ClientInfo,
+        message_id: MessageId,
+    ) -> Option<Action> {
         Some(Action::ForwardClientRequest(Rpc::Request {
             requester: client.public_id.clone(),
             request,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2829,6 +2829,8 @@ fn delete_mutable_data() {
         &mut client_a,
         Request::PutMData(MData::Unseq(mdata.clone())),
     );
+    let balance_a = unwrap!(balance_a.checked_sub(*COST_OF_PUT));
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
 
     // Attempt to delete non-existent data.
     let invalid_address = MDataAddress::from_kind(MDataKind::Unseq, env.rng().gen(), 101);
@@ -2838,6 +2840,7 @@ fn delete_mutable_data() {
         Request::DeleteMData(invalid_address),
         NdError::NoSuchData,
     );
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
 
     // Attempt to delete the data by non-owner.
     common::send_request_expect_err(
@@ -2846,9 +2849,11 @@ fn delete_mutable_data() {
         Request::DeleteMData(address),
         NdError::AccessDenied,
     );
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
 
     // Successfully delete.
     common::send_request_expect_ok(&mut env, &mut client_a, Request::DeleteMData(address), ());
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
 
     // Verify the data doesn't exist any more.
     common::send_request_expect_err(


### PR DESCRIPTION
- Make `DeleteMData` free of charge
- Rename `handle_mdata_mutation` to `handle_mutate_mdata` to fit the
  pattern used by other functions
- `handle_delete_mdata()` and `handle_get_mdata()` are now the same,
  however I'm not convinced to makes sense to use the same function for
  both of these cases.