### PR TITLE
chore/ci: remove deploy directory from publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ ifndef CRATES_IO_TOKEN
 	@echo "A login token for crates.io must be provided."
 	@exit 1
 endif
-	rm -rf artifacts
+	rm -rf artifacts deploy
 	docker run --rm -v "${PWD}":/usr/src/safe_vault:Z \
 		-u ${USER_ID}:${GROUP_ID} \
 		maidsafe/safe-vault-build:build \


### PR DESCRIPTION
This is an extra directory that will cause the 'cargo package' command to fail.