### PR TITLE
Add verbose command line flag

### DIFF
--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -115,6 +115,7 @@ impl ClientHandler {
                 );
             }
         }
+        println!("Waiting for connections ...");
 
         Ok((quic_p2p, event_receiver))
     }


### PR DESCRIPTION
Adds a command line argument `-v` that can be repeated like `-vv` to increase verbosity in the console output. It is equivalent to and overrides RUST_LOG if present.