### PR TITLE
Release Process Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.rsproj
 tags*
 artifacts/
+deploy/
 build/
 build-tests/
 target/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ stage("build & test") {
         node("safe_vault") {
             checkout(scm)
             sh("make musl")
+            stripArtifacts()
             packageBuildArtifacts("linux")
             uploadBuildArtifacts()
         }
@@ -45,6 +46,7 @@ stage("build & test") {
         node("windows") {
             checkout(scm)
             runReleaseBuild()
+            stripArtifacts()
             packageBuildArtifacts("windows")
             uploadBuildArtifacts()
         }
@@ -53,6 +55,7 @@ stage("build & test") {
         node("osx") {
             checkout(scm)
             runReleaseBuild()
+            stripArtifacts()
             packageBuildArtifacts("macos")
             uploadBuildArtifacts()
         }
@@ -93,6 +96,10 @@ def runReleaseBuild() {
     } else {
         sh("make build")
     }
+}
+
+def stripArtifacts() {
+    sh("make strip-artifacts")
 }
 
 def retrieveCache() {

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ endif
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_VAULT_VERSION} \
 		--name "safe-vault" \
-		--description "Command line interface for the SAFE Network";
+		--description "$$(./scripts/get_release_description.sh ${SAFE_VAULT_VERSION})"
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,20 @@ GITHUB_REPO_NAME := safe_vault
 build-container:
 	rm -rf target/
 	docker rmi -f maidsafe/safe-vault-build:build
-	docker build -f Dockerfile.build -t maidsafe/safe-vault-build:build .
+	docker build -f Dockerfile.build -t maidsafe/safe-vault-build:build \
+		--build-arg build_type="non-mock" .
+
+build-mock-container:
+	rm -rf target/
+	docker rmi -f maidsafe/safe-vault-build:build-mock
+	docker build -f Dockerfile.build -t maidsafe/safe-vault-build:build-mock \
+		--build-arg build_type="mock" .
 
 push-container:
 	docker push maidsafe/safe-vault-build:build
+
+push-mock-container:
+	docker push maidsafe/safe-cli-build:build-mock
 
 clippy:
 ifeq ($(UNAME_S),Linux)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,15 @@ else
 endif
 	find target/release -maxdepth 1 -type f -exec cp '{}' artifacts \;
 
+strip-artifacts:
+ifeq ($(OS),Windows_NT)
+	find artifacts -name "safe_vault.exe" -exec strip -x '{}' \;
+else ifeq ($(UNAME_S),Darwin)
+	find artifacts -name "safe_vault" -exec strip -x '{}' \;
+else
+	find artifacts -name "safe_vault" -exec strip '{}' \;
+endif
+
 build-container:
 	rm -rf target/
 	docker rmi -f maidsafe/safe-vault-build:build
@@ -169,23 +178,23 @@ package-commit_hash-artifacts-for-deploy:
 	mv safe_vault-$$(git rev-parse --short HEAD)-x86_64-pc-windows-gnu.tar deploy
 	mv safe_vault-$$(git rev-parse --short HEAD)-x86_64-apple-darwin.tar deploy
 
+.ONESHELL:
 package-version-artifacts-for-deploy:
-	rm -f *.tar
 	rm -rf deploy
 	mkdir deploy
 	cd deploy
-	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-gnu.zip \
-		../../artifacts/linux/release/safe
+	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.zip \
+		../artifacts/linux/release/safe_vault
 	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.zip \
-		../../artifacts/win/release/safe.exe
+		../artifacts/win/release/safe_vault.exe
 	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.zip \
-		../../artifacts/macos/release/safe
-	tar -C ../../artifacts/linux/release \
-		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar.gz safe
-	tar -C ../../artifacts/win/release \
-		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar.gz safe.exe
-	tar -C ../../artifacts/macos/release \
-		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar.gz safe
+		../artifacts/macos/release/safe_vault
+	tar -C ../artifacts/linux/release \
+		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar.gz safe_vault
+	tar -C ../artifacts/win/release \
+		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar.gz safe_vault.exe
+	tar -C ../artifacts/macos/release \
+		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar.gz safe_vault
 
 deploy-github-release:
 ifndef GITHUB_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -173,12 +173,19 @@ package-version-artifacts-for-deploy:
 	rm -f *.tar
 	rm -rf deploy
 	mkdir deploy
-	tar -C artifacts/linux/release -cvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar safe_vault
-	tar -C artifacts/win/release -cvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar safe_vault.exe
-	tar -C artifacts/macos/release -cvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar safe_vault
-	mv safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar deploy
-	mv safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar deploy
-	mv safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar deploy
+	cd deploy
+	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-gnu.zip \
+		../../artifacts/linux/release/safe
+	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.zip \
+		../../artifacts/win/release/safe.exe
+	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.zip \
+		../../artifacts/macos/release/safe
+	tar -C ../../artifacts/linux/release \
+		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar.gz safe
+	tar -C ../../artifacts/win/release \
+		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar.gz safe.exe
+	tar -C ../../artifacts/macos/release \
+		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar.gz safe
 
 deploy-github-release:
 ifndef GITHUB_TOKEN
@@ -195,20 +202,38 @@ endif
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_VAULT_VERSION} \
-		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar" \
-		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar;
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.zip" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.zip
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_VAULT_VERSION} \
-		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar" \
-		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar;
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.zip" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.zip
 	github-release upload \
 		--user ${GITHUB_REPO_OWNER} \
 		--repo ${GITHUB_REPO_NAME} \
 		--tag ${SAFE_VAULT_VERSION} \
-		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar" \
-		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar;
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.zip" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.zip
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_VAULT_VERSION} \
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_VAULT_VERSION} \
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar.gz" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-gnu.tar.gz
+	github-release upload \
+		--user ${GITHUB_REPO_OWNER} \
+		--repo ${GITHUB_REPO_NAME} \
+		--tag ${SAFE_VAULT_VERSION} \
+		--name "safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar.gz" \
+		--file deploy/safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar.gz
 
 publish:
 ifndef CRATES_IO_TOKEN

--- a/scripts/build-cache.sh
+++ b/scripts/build-cache.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ -z "$build_type" ]]; then
+    echo "build_type must be set to mock or non-mock"
+    exit 1
+fi
+
+if [[ "$build_type" == "mock" ]]; then
+    cargo test --release --features=mock --no-default-features
+else
+    cargo build --release
+fi

--- a/scripts/get_release_description.sh
+++ b/scripts/get_release_description.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+version=$1
+if [[ -z "$version" ]]; then
+    echo "You must supply a version number."
+    exit 1
+fi
+
+# The single quotes around EOF is to stop attempted variable and backtick expansion.
+read -r -d '' release_description << 'EOF'
+Implements a SAFE Network Vault.
+
+## SHA-256 checksums for release versions:
+```
+Linux
+zip: ZIP_LINUX_CHECKSUM
+tar.gz: TAR_LINUX_CHECKSUM
+
+macOS
+zip: ZIP_MACOS_CHECKSUM
+tar.gz: TAR_MACOS_CHECKSUM
+
+Windows
+zip: ZIP_WIN_CHECKSUM
+tar.gz: TAR_WIN_CHECKSUM
+```
+
+## Related Links
+* [SAFE CLI](https://github.com/maidsafe/safe-cli/releases/latest/)
+* [SAFE Authenticator CLI](https://github.com/maidsafe/safe-authenticator-cli/releases/latest/)
+* [SAFE Browser PoC](https://github.com/maidsafe/safe_browser/releases/)
+EOF
+
+zip_linux_checksum=$(sha256sum \
+    "./deploy/release/safe_vault-$version-x86_64-unknown-linux-musl.zip" | \
+    awk '{ print $1 }')
+zip_macos_checksum=$(sha256sum \
+    "./deploy/release/safe_vault-$version-x86_64-apple-darwin.zip" | \
+    awk '{ print $1 }')
+zip_win_checksum=$(sha256sum \
+    "./deploy/release/safe_vault-$version-x86_64-pc-windows-gnu.zip" | \
+    awk '{ print $1 }')
+tar_linux_checksum=$(sha256sum \
+    "./deploy/release/safe_vault-$version-x86_64-unknown-linux-musl.tar.gz" | \
+    awk '{ print $1 }')
+tar_macos_checksum=$(sha256sum \
+    "./deploy/release/safe_vault-$version-x86_64-apple-darwin.tar.gz" | \
+    awk '{ print $1 }')
+tar_win_checksum=$(sha256sum \
+    "./deploy/release/safe_vault-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    awk '{ print $1 }')
+
+release_description=$(sed "s/ZIP_LINUX_CHECKSUM/$zip_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_MACOS_CHECKSUM/$zip_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/ZIP_WIN_CHECKSUM/$zip_win_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_LINUX_CHECKSUM/$tar_linux_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_MACOS_CHECKSUM/$tar_macos_checksum/g" <<< "$release_description")
+release_description=$(sed "s/TAR_WIN_CHECKSUM/$tar_win_checksum/g" <<< "$release_description")
+echo "$release_description"

--- a/scripts/get_release_description.sh
+++ b/scripts/get_release_description.sh
@@ -32,22 +32,22 @@ tar.gz: TAR_WIN_CHECKSUM
 EOF
 
 zip_linux_checksum=$(sha256sum \
-    "./deploy/release/safe_vault-$version-x86_64-unknown-linux-musl.zip" | \
+    "./deploy/safe_vault-$version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 zip_macos_checksum=$(sha256sum \
-    "./deploy/release/safe_vault-$version-x86_64-apple-darwin.zip" | \
+    "./deploy/safe_vault-$version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 zip_win_checksum=$(sha256sum \
-    "./deploy/release/safe_vault-$version-x86_64-pc-windows-gnu.zip" | \
+    "./deploy/safe_vault-$version-x86_64-pc-windows-gnu.zip" | \
     awk '{ print $1 }')
 tar_linux_checksum=$(sha256sum \
-    "./deploy/release/safe_vault-$version-x86_64-unknown-linux-musl.tar.gz" | \
+    "./deploy/safe_vault-$version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 tar_macos_checksum=$(sha256sum \
-    "./deploy/release/safe_vault-$version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/safe_vault-$version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 tar_win_checksum=$(sha256sum \
-    "./deploy/release/safe_vault-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    "./deploy/safe_vault-$version-x86_64-pc-windows-gnu.tar.gz" | \
     awk '{ print $1 }')
 
 release_description=$(sed "s/ZIP_LINUX_CHECKSUM/$zip_linux_checksum/g" <<< "$release_description")


### PR DESCRIPTION
Hi Nikita,

Following on from that thread on Slack today, I decided to do clean release builds as separate jobs. The cleaning only applies to the `master` branch and not PRs. We do this so we know the stuff we're releasing doesn't have any caching problems creeping in.

Other than that, this also does:

* Distribute both zips and tar.gz (request by community)
* Strip the build artifacts (request by community)
* Adds sha256 checksums to the release description

There is an [example](https://github.com/jacderida/safe_vault/releases/tag/0.19.1) release on my fork.

Cheers,

Chris