### PR TITLE
Improve app authorisation

### DIFF
--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -1525,8 +1525,9 @@ impl ClientHandler {
     ) -> Option<()> {
         let signature_required = match utils::authorisation_kind(request) {
             AuthorisationKind::GetUnpub
+            | AuthorisationKind::GetBalance
             | AuthorisationKind::Mut
-            | AuthorisationKind::GetBalance => true,
+            | AuthorisationKind::ManageAppKeys => true,
             AuthorisationKind::GetPub => false,
         };
 
@@ -1578,6 +1579,7 @@ impl ClientHandler {
             AuthorisationKind::Mut => {
                 self.check_app_permissions(app_id, |perms| perms.transfer_coins)
             }
+            AuthorisationKind::ManageAppKeys => Err(NdError::AccessDenied),
         };
 
         if let Err(error) = result {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -151,6 +151,8 @@ pub(crate) enum AuthorisationKind {
     GetBalance,
     // Mutation request.
     Mut,
+    // Request to manage app keys.
+    ManageAppKeys,
 }
 
 // Returns the type of authorisation needed for the given request.
@@ -176,9 +178,7 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | CreateBalance { .. }
         | CreateLoginPacket(_)
         | CreateLoginPacketFor { .. }
-        | UpdateLoginPacket(_)
-        | InsAuthKey { .. }
-        | DelAuthKey { .. } => AuthorisationKind::Mut,
+        | UpdateLoginPacket(_) => AuthorisationKind::Mut,
         GetIData(IDataAddress::Pub(_)) => AuthorisationKind::GetPub,
         GetIData(IDataAddress::Unpub(_))
         | GetMData(_)
@@ -190,8 +190,7 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | ListMDataValues(_)
         | ListMDataPermissions(_)
         | ListMDataUserPermissions { .. }
-        | GetLoginPacket(_)
-        | ListAuthKeysAndVersion => AuthorisationKind::GetUnpub,
+        | GetLoginPacket(_) => AuthorisationKind::GetUnpub,
         GetAData(address)
         | GetADataValue { address, .. }
         | GetADataShell { address, .. }
@@ -209,5 +208,8 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
             }
         }
         GetBalance => AuthorisationKind::GetBalance,
+        ListAuthKeysAndVersion | InsAuthKey { .. } | DelAuthKey { .. } => {
+            AuthorisationKind::ManageAppKeys
+        }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -486,16 +486,6 @@ pub fn send_request_expect_err<T: TestClientTrait>(
     assert_eq!(expected_response, client.expect_response(message_id));
 }
 
-pub fn send_request_expect_no_response<T: TestClientTrait>(
-    env: &mut Environment,
-    client: &mut T,
-    request: Request,
-) {
-    let _message_id = client.send_request(request);
-    env.poll();
-    client.expect_no_new_message();
-}
-
 pub fn create_balance(
     env: &mut Environment,
     src_client: &mut TestClient,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2248,14 +2248,28 @@ fn auth_keys() {
     list_keys(&mut env, &mut owner, Ok((expected_map.clone(), 1)));
 
     // Check the app isn't allowed to get a listing of authorised keys, nor insert, nor delete any.
-    // No response should be returned to any of these requests.
-    common::send_request_expect_no_response(&mut env, &mut app, Request::ListAuthKeysAndVersion);
-    common::send_request_expect_no_response(&mut env, &mut app, make_ins_request(2));
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        Request::ListAuthKeysAndVersion,
+        NdError::AccessDenied,
+    );
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        make_ins_request(2),
+        NdError::AccessDenied,
+    );
     let del_auth_key_request = Request::DelAuthKey {
         key: *app.public_id().public_key(),
         version: 2,
     };
-    common::send_request_expect_no_response(&mut env, &mut app, del_auth_key_request.clone());
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        del_auth_key_request.clone(),
+        NdError::AccessDenied,
+    );
 
     // Remove the app, then list the keys.
     common::perform_mutation(&mut env, &mut owner, del_auth_key_request);


### PR DESCRIPTION
Closes #836 

Note: before this PR, we used to return no response in case an app attempted to send `ListAuthKeysAndVersion`, `InsAuthKey` or `DelAuthKey`. This PR changes that to respond with `Error::AccessDenied`.