### PR TITLE
add initial ParsecAction with immediate execution

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -8,9 +8,11 @@
 
 use crate::rpc::Rpc;
 use safe_nd::{Coins, MessageId, PublicId, Request, XorName};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+// Need to Serialize/Deserialize to go through Parsec
 pub(crate) enum ParsecAction {
     // Process pay for request and forward request to client.
     PayAndForwardClientRequest {
@@ -24,8 +26,11 @@ pub(crate) enum ParsecAction {
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Action {
+    // Trigger a vote for an event so we can process the deferred action on consensus.
+    // (Currently immediately.)
+    ParsecVote(ParsecAction),
     // Process deferred action (eventually will wait for Parsec consensus).
-    Parsec(ParsecAction),
+    ParsecConsensus(ParsecAction),
     // Send a validated client request from client handlers to the appropriate destination.
     ForwardClientRequest(Rpc),
     // Send a request from client handlers of Client A to Client B to then be handled as if Client B

--- a/src/action.rs
+++ b/src/action.rs
@@ -7,12 +7,25 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::rpc::Rpc;
-use safe_nd::XorName;
+use safe_nd::{Coins, MessageId, PublicId, Request, XorName};
 use std::collections::BTreeSet;
+
+#[derive(Debug)]
+pub(crate) enum ParsecAction {
+    // Process pay for request and forward request to client.
+    PayAndForwardClientRequest {
+        request: Request,
+        client_public_id: PublicId,
+        message_id: MessageId,
+        cost: Coins,
+    },
+}
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Action {
+    // Process deferred action (eventually will wait for Parsec consensus).
+    Parsec(ParsecAction),
     // Send a validated client request from client handlers to the appropriate destination.
     ForwardClientRequest(Rpc),
     // Send a request from client handlers of Client A to Client B to then be handled as if Client B

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -448,12 +448,14 @@ impl ClientHandler {
         client: &ClientInfo,
         message_id: MessageId,
     ) -> Option<Action> {
-        Some(Action::Parsec(ParsecAction::PayAndForwardClientRequest {
-            request,
-            client_public_id: client.public_id.clone(),
-            message_id,
-            cost: *COST_OF_PUT,
-        }))
+        Some(Action::ParsecVote(
+            ParsecAction::PayAndForwardClientRequest {
+                request,
+                client_public_id: client.public_id.clone(),
+                message_id,
+                cost: *COST_OF_PUT,
+            },
+        ))
     }
 
     fn handle_delete_mdata(

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -496,19 +496,15 @@ impl ClientHandler {
         }
 
         let request = Request::PutMData(chunk);
-        self.pay(
-            &client.public_id,
-            owner.public_key(),
-            &request,
-            message_id,
-            *COST_OF_PUT,
-        )?;
 
-        Some(Action::ForwardClientRequest(Rpc::Request {
-            requester: client.public_id.clone(),
-            request,
-            message_id,
-        }))
+        Some(Action::ParsecVote(
+            ParsecAction::PayAndForwardClientRequest {
+                request,
+                client_public_id: client.public_id.clone(),
+                message_id,
+                cost: *COST_OF_PUT,
+            },
+        ))
     }
 
     fn handle_put_idata(
@@ -539,19 +535,14 @@ impl ClientHandler {
         }
 
         let request = Request::PutIData(chunk);
-        self.pay(
-            &client.public_id,
-            owner.public_key(),
-            &request,
-            message_id,
-            *COST_OF_PUT,
-        )?;
-
-        Some(Action::ForwardClientRequest(Rpc::Request {
-            requester: client.public_id.clone(),
-            request,
-            message_id,
-        }))
+        Some(Action::ParsecVote(
+            ParsecAction::PayAndForwardClientRequest {
+                request,
+                client_public_id: client.public_id.clone(),
+                message_id,
+                cost: *COST_OF_PUT,
+            },
+        ))
     }
 
     fn handle_get_idata(
@@ -625,19 +616,14 @@ impl ClientHandler {
         }
 
         let request = Request::PutAData(chunk);
-        self.pay(
-            &client.public_id,
-            owner.public_key(),
-            &request,
-            message_id,
-            *COST_OF_PUT,
-        )?;
-
-        Some(Action::ForwardClientRequest(Rpc::Request {
-            requester: client.public_id.clone(),
-            request,
-            message_id,
-        }))
+        Some(Action::ParsecVote(
+            ParsecAction::PayAndForwardClientRequest {
+                request,
+                client_public_id: client.public_id.clone(),
+                message_id,
+                cost: *COST_OF_PUT,
+            },
+        ))
     }
 
     fn handle_delete_adata(
@@ -668,20 +654,14 @@ impl ClientHandler {
         request: Request,
         message_id: MessageId,
     ) -> Option<Action> {
-        let owner = utils::owner(&client.public_id)?;
-        self.pay(
-            &client.public_id,
-            owner.public_key(),
-            &request,
-            message_id,
-            *COST_OF_PUT,
-        )?;
-
-        Some(Action::ForwardClientRequest(Rpc::Request {
-            requester: client.public_id.clone(),
-            request,
-            message_id,
-        }))
+        Some(Action::ParsecVote(
+            ParsecAction::PayAndForwardClientRequest {
+                request,
+                client_public_id: client.public_id.clone(),
+                message_id,
+                cost: *COST_OF_PUT,
+            },
+        ))
     }
 
     /// Handles a received challenge response.

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -200,7 +200,8 @@ impl Vault {
     fn handle_action(&mut self, action: Action) -> Option<Action> {
         use Action::*;
         match action {
-            Parsec(action) => self.client_handler_mut()?.handle_parsec_action(action),
+            ParsecVote(action) => Some(ParsecConsensus(action)),
+            ParsecConsensus(action) => self.client_handler_mut()?.handle_parsec_action(action),
             ForwardClientRequest(rpc) => self.forward_client_request(rpc),
             ProxyClientRequest(rpc) => self.proxy_client_request(rpc),
             RespondToOurDataHandlers { sender, rpc } => {

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -200,6 +200,7 @@ impl Vault {
     fn handle_action(&mut self, action: Action) -> Option<Action> {
         use Action::*;
         match action {
+            Parsec(action) => self.client_handler_mut()?.handle_parsec_action(action),
             ForwardClientRequest(rpc) => self.forward_client_request(rpc),
             ProxyClientRequest(rpc) => self.proxy_client_request(rpc),
             RespondToOurDataHandlers { sender, rpc } => {


### PR DESCRIPTION
Closes #841 

Initial flow to allow Parsec to be used at the pay step.
All the similar data mutation are handled the same way with a vote that result in the pay and forward request action to be executed immediately.

To move to real parsec:
Convert that line to a vote `ParsecVote(action) => Some(ParsecConsensus(action))` and return None action. And on consensus create an action and handle it. 
