### PR TITLE
Support multi vault tests

### DIFF
--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -66,6 +66,7 @@ fn main() {
 mod detail {
     use env_logger::{fmt::Formatter, Builder as LoggerBuilder};
     use log::{self, Level, Record};
+    use safe_vault::routing::Node;
     use safe_vault::{self, Command, Config, Vault};
     use self_update::cargo_crate_version;
     use self_update::Status;
@@ -128,7 +129,15 @@ mod detail {
             log::error!("Failed to set interrupt handler: {:?}", error)
         }
 
-        match Vault::new(config, command_rx) {
+        let routing_node = match Node::builder().create() {
+            Ok(node) => node,
+            Err(e) => {
+                eprintln!("Could not start a Routing node: {:?}", e);
+                process::exit(-1);
+            }
+        };
+
+        match Vault::new(routing_node, config, command_rx) {
             Ok(mut vault) => vault.run(),
             Err(e) => {
                 println!("Cannot start vault due to error: {:?}", e);

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -173,6 +173,7 @@ impl ClientHandler {
 
     pub fn handle_consensused_action(&mut self, action: ConsensusAction) -> Option<Action> {
         use ConsensusAction::*;
+        trace!("{}: Consensused {:?}", self, action,);
         match action {
             PayAndForward {
                 request,
@@ -972,7 +973,11 @@ impl ClientHandler {
             .map(|key| key == &owner_key)
             .unwrap_or(false);
         if own_request {
-            return Some(action);
+            return Some(Action::ConsensusVote(ConsensusAction::Forward {
+                request,
+                client_public_id: requester.clone(),
+                message_id,
+            }));
         }
 
         self.pay(

--- a/src/mock_routing.rs
+++ b/src/mock_routing.rs
@@ -7,11 +7,39 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crossbeam_channel::TryRecvError;
+use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::rc::{Rc, Weak};
+
+/// Consensus group reference
+pub type ConsensusGroupRef = Rc<RefCell<ConsensusGroup>>;
+type EventsRef = Rc<RefCell<VecDeque<Vec<u8>>>>;
+
+/// Consensus
+pub struct ConsensusGroup {
+    pub(crate) event_buckets: Vec<EventsRef>,
+}
+
+impl ConsensusGroup {
+    /// Creates a new consensus group.
+    pub fn new() -> ConsensusGroupRef {
+        Rc::new(RefCell::new(ConsensusGroup {
+            event_buckets: Vec::new(),
+        }))
+    }
+
+    fn vote_for(&self, event: Vec<u8>) {
+        for bucket in &self.event_buckets {
+            let mut events = bucket.borrow_mut();
+            events.push_back(event.clone());
+        }
+    }
+}
 
 /// Interface for sending and receiving messages to and from other nodes, in the role of a full routing node.
 pub struct Node {
-    events: VecDeque<Vec<u8>>,
+    events: EventsRef,
+    consensus_group: Option<Weak<RefCell<ConsensusGroup>>>,
 }
 
 impl Node {
@@ -22,7 +50,13 @@ impl Node {
 
     /// Vote for an event.
     pub fn vote_for(&mut self, event: Vec<u8>) {
-        self.events.push_back(event);
+        if let Some(ref consensus_group) = self.consensus_group {
+            let _ = consensus_group
+                .upgrade()
+                .map(|group| group.borrow_mut().vote_for(event));
+        } else {
+            self.events.borrow_mut().push_back(event);
+        }
     }
 
     /// Try to read the next available event from the stream without blocking.
@@ -30,7 +64,7 @@ impl Node {
     /// Implementations should return an error if there are no items available, OR
     /// a real error occurs.
     pub fn try_next_ev(&mut self) -> Result<Event, TryRecvError> {
-        if let Some(event) = self.events.pop_front() {
+        if let Some(event) = self.events.borrow_mut().pop_front() {
             Ok(Event::Consensus(event))
         } else {
             Err(TryRecvError::Empty)
@@ -45,12 +79,32 @@ impl NodeBuilder {
     /// Creates new `Node`.
     pub fn create(self) -> Result<Node, RoutingError> {
         Ok(Node {
-            events: VecDeque::with_capacity(128),
+            events: Rc::new(RefCell::new(VecDeque::with_capacity(128))),
+            consensus_group: None,
+        })
+    }
+
+    /// Creates new `Node` within a section of nodes.
+    pub fn create_within_group(
+        self,
+        consensus_group: Rc<RefCell<ConsensusGroup>>,
+    ) -> Result<Node, RoutingError> {
+        let event_bucket = Rc::new(RefCell::new(VecDeque::with_capacity(128)));
+
+        consensus_group
+            .borrow_mut()
+            .event_buckets
+            .push(event_bucket.clone());
+
+        Ok(Node {
+            events: event_bucket.clone(),
+            consensus_group: Some(Rc::downgrade(&consensus_group)),
         })
     }
 }
 
 /// Routing event.
+#[derive(Debug)]
 pub enum Event {
     /// Event from PARSEC.
     Consensus(Vec<u8>),

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -68,7 +68,11 @@ pub struct Vault {
 
 impl Vault {
     /// Construct a new vault instance.
-    pub fn new(config: Config, command_receiver: Receiver<Command>) -> Result<Self> {
+    pub fn new(
+        routing_node: Node,
+        config: Config,
+        command_receiver: Receiver<Command>,
+    ) -> Result<Self> {
         let mut init_mode = Init::Load;
         let (is_elder, id) = Self::read_state(&config)?.unwrap_or_else(|| {
             let mut rng = rand::thread_rng();
@@ -77,7 +81,6 @@ impl Vault {
             (true, id)
         });
 
-        let routing_node = Node::builder().create()?;
         let root_dir = config.root_dir()?;
         let root_dir = root_dir.as_path();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,6 +24,7 @@ use safe_nd::{
 use safe_vault::{
     mock::Network,
     quic_p2p::{self, Builder, Event, NodeInfo, OurType, Peer, QuicP2p},
+    routing::{ConsensusGroup, ConsensusGroupRef, Node},
     Config, Vault,
 };
 use serde::Serialize;
@@ -47,11 +48,12 @@ macro_rules! unexpected {
 pub struct Environment {
     rng: TestRng,
     network: Network,
-    vault: TestVault,
+    vaults: Vec<TestVault>,
+    _consensus_group: ConsensusGroupRef,
 }
 
 impl Environment {
-    pub fn new() -> Self {
+    pub fn with_multiple_vaults(num_vaults: usize) -> Self {
         let do_format = move |formatter: &mut Formatter, record: &Record<'_>| {
             let now = formatter.timestamp();
             writeln!(
@@ -73,11 +75,25 @@ impl Environment {
         let mut rng = rng::new();
         let network_rng = rng::from_rng(&mut rng);
 
+        let network = Network::new(network_rng);
+
+        let consensus_group = ConsensusGroup::new();
+
+        let mut vaults = Vec::with_capacity(num_vaults);
+        for _i in 0..num_vaults {
+            vaults.push(TestVault::in_group(Some(consensus_group.clone())));
+        }
+
         Self {
             rng,
-            network: Network::new(network_rng),
-            vault: TestVault::new(),
+            network,
+            vaults,
+            _consensus_group: consensus_group,
         }
+    }
+
+    pub fn new() -> Self {
+        Self::with_multiple_vaults(4)
     }
 
     pub fn rng(&mut self) -> &mut TestRng {
@@ -89,7 +105,7 @@ impl Environment {
         let mut progress = true;
         while progress {
             self.network.poll();
-            progress = self.vault.inner.poll();
+            progress = self.vaults.iter_mut().any(|vault| vault.inner.poll());
         }
     }
 
@@ -110,7 +126,7 @@ impl Environment {
     }
 
     pub fn establish_connection<T: TestClientTrait>(&mut self, client: &mut T) {
-        let conn_info = self.vault.connection_info();
+        let conn_info = self.vaults[0].connection_info();
         client.quic_p2p().connect_to(conn_info.clone());
         self.poll();
 
@@ -130,7 +146,8 @@ struct TestVault {
 }
 
 impl TestVault {
-    fn new() -> Self {
+    /// Create a test Vault within a group.
+    fn in_group(consensus_group: Option<ConsensusGroupRef>) -> Self {
         let root_dir = unwrap!(TempDir::new("safe_vault"));
 
         let mut config = Config::default();
@@ -138,12 +155,22 @@ impl TestVault {
 
         let (_, command_rx) = crossbeam_channel::bounded(0);
 
-        let inner = unwrap!(Vault::new(config, command_rx));
+        let routing_node = if let Some(group) = consensus_group {
+            unwrap!(Node::builder().create_within_group(group))
+        } else {
+            unwrap!(Node::builder().create())
+        };
+        let inner = unwrap!(Vault::new(routing_node, config, command_rx));
 
         Self {
             inner,
             _root_dir: root_dir,
         }
+    }
+
+    #[allow(unused)]
+    fn new() -> Self {
+        Self::in_group(None)
     }
 
     fn connection_info(&mut self) -> NodeInfo {


### PR DESCRIPTION
Closes #853

This PR also covers the consensus for the `CreateBalance` request and partially addresses some other requirements for the multi-vault testing environment (e.g.: running the existing test suite with multiple vaults).