### PR TITLE
Handle refunds when errors are returned from the data handlers

### DIFF
--- a/src/data_handler.rs
+++ b/src/data_handler.rs
@@ -68,10 +68,6 @@ impl DataHandler {
                 message_id,
                 ..
             } => self.handle_response(src, response, message_id),
-            _ => {
-                error!("{}: Received invalid vault RPC: {:?}", self, rpc);
-                None
-            }
         }
     }
 

--- a/src/data_handler/adata_handler.rs
+++ b/src/data_handler/adata_handler.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, AppendOnlyChunkStore},
@@ -66,11 +65,7 @@ impl ADataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {
@@ -535,11 +530,7 @@ impl ADataHandler {
                     .put(&adata)
                     .map_err(|error| error.to_string().into())
             });
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {

--- a/src/data_handler/adata_handler.rs
+++ b/src/data_handler/adata_handler.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, AppendOnlyChunkStore},
@@ -65,12 +66,18 @@ impl ADataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -108,6 +115,8 @@ impl ADataHandler {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                // Deletion is free so no refund
+                refund: None,
             },
         })
     }
@@ -126,6 +135,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetAData(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -147,6 +157,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataShell(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -168,6 +179,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataRange(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -188,6 +200,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataIndices(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -208,6 +221,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataLastEntry(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -234,6 +248,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataOwners(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -256,6 +271,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetPubADataUserPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -278,6 +294,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetUnpubADataUserPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -310,6 +327,7 @@ impl ADataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -331,6 +349,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataValue(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -516,12 +535,18 @@ impl ADataHandler {
                     .put(&adata)
                     .map_err(|error| error.to_string().into())
             });
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {
                 requester: requester.clone(),
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }

--- a/src/data_handler/idata_handler.rs
+++ b/src/data_handler/idata_handler.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{IDataOp, IDataRequest, OpType};
-use crate::client_handler::COST_OF_PUT;
 use crate::{action::Action, rpc::Rpc, utils, vault::Init, Config, Result, ToDbKey};
 use log::{trace, warn};
 use pickledb::PickleDb;
@@ -65,11 +64,7 @@ impl IDataHandler {
 
         let client_id = requester.clone();
         let respond = |result: NdResult<()>| {
-            let refund = if result.is_err() {
-                Some(*COST_OF_PUT)
-            } else {
-                None
-            };
+            let refund = utils::get_refund_for_put(&result);
             Some(Action::RespondToClientHandlers {
                 sender: data_name,
                 rpc: Rpc::Response {

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action, chunk_store::ImmutableChunkStore, rpc::Rpc, utils, vault::Init, Config, Result,
 };
@@ -61,11 +60,7 @@ impl IDataHolder {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToOurDataHandlers {
             sender: *self.id.name(),
             rpc: Rpc::Response {

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action, chunk_store::ImmutableChunkStore, rpc::Rpc, utils, vault::Init, Config, Result,
 };
@@ -60,13 +61,18 @@ impl IDataHolder {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToOurDataHandlers {
             sender: *self.id.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -99,6 +105,7 @@ impl IDataHolder {
                 requester: client.clone(),
                 response: Response::GetIData(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -144,6 +151,7 @@ impl IDataHolder {
                 requester: client.clone(),
                 response: Response::Mutation(result),
                 message_id,
+                refund: None,
             },
         })
     }

--- a/src/data_handler/idata_op.rs
+++ b/src/data_handler/idata_op.rs
@@ -175,6 +175,7 @@ impl IDataOp {
                     requester: self.client().clone(),
                     response,
                     message_id,
+                    refund: None,
                 },
             })
         }

--- a/src/data_handler/mdata_handler.rs
+++ b/src/data_handler/mdata_handler.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, MutableChunkStore},
@@ -107,11 +106,7 @@ impl MDataHandler {
                     .put(&mdata)
                     .map_err(|error| error.to_string().into())
             });
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {
@@ -137,11 +132,7 @@ impl MDataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {

--- a/src/data_handler/mdata_handler.rs
+++ b/src/data_handler/mdata_handler.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, MutableChunkStore},
@@ -106,13 +107,18 @@ impl MDataHandler {
                     .put(&mdata)
                     .map_err(|error| error.to_string().into())
             });
-
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -131,12 +137,18 @@ impl MDataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -170,6 +182,8 @@ impl MDataHandler {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                // Deletion is free so no refund
+                refund: None,
             },
         })
     }
@@ -242,6 +256,7 @@ impl MDataHandler {
                 requester,
                 response: Response::GetMData(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -263,6 +278,7 @@ impl MDataHandler {
                 requester,
                 response: Response::GetMDataShell(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -284,6 +300,7 @@ impl MDataHandler {
                 requester,
                 response: Response::GetMDataVersion(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -319,6 +336,7 @@ impl MDataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -340,6 +358,7 @@ impl MDataHandler {
                 requester,
                 response: Response::ListMDataKeys(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -364,6 +383,7 @@ impl MDataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -388,6 +408,7 @@ impl MDataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -409,6 +430,7 @@ impl MDataHandler {
                 requester,
                 response: Response::ListMDataPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -431,6 +453,7 @@ impl MDataHandler {
                 requester,
                 response: Response::ListMDataUserPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -8,7 +8,7 @@
 
 //! RPC messages internal to Vaults.
 
-use safe_nd::{Coins, Error as NdError, MessageId, PublicId, Request, Response, TransactionId};
+use safe_nd::{Coins, MessageId, PublicId, Request, Response};
 use serde::{Deserialize, Serialize};
 
 /// RPC messages exchanged between nodes.
@@ -27,13 +27,5 @@ pub(crate) enum Rpc {
         requester: PublicId,
         message_id: MessageId,
         refund: Option<Coins>,
-    },
-    /// Refund for a failed coin transfer. Send between ClientHandlers.
-    Refund {
-        requester: PublicId,
-        amount: Coins,
-        transaction_id: TransactionId,
-        reason: NdError,
-        message_id: MessageId,
     },
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -26,6 +26,7 @@ pub(crate) enum Rpc {
         response: Response,
         requester: PublicId,
         message_id: MessageId,
+        refund: Option<Coins>,
     },
     /// Refund for a failed coin transfer. Send between ClientHandlers.
     Refund {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,12 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{rpc::Rpc, vault::Init, Result};
 use bincode;
 use log::{error, trace};
 use pickledb::{PickleDb, PickleDbDumpPolicy};
 use rand::{distributions::Standard, thread_rng, Rng};
-use safe_nd::{ClientPublicId, IDataAddress, PublicId, PublicKey, Request, XorName};
+use safe_nd::{
+    ClientPublicId, Coins, IDataAddress, PublicId, PublicKey, Request, Result as NdResult, XorName,
+};
 use serde::Serialize;
 use std::{borrow::Cow, fs, path::Path};
 use unwrap::unwrap;
@@ -220,5 +223,13 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         ListAuthKeysAndVersion | InsAuthKey { .. } | DelAuthKey { .. } => {
             AuthorisationKind::ManageAppKeys
         }
+    }
+}
+
+pub(crate) fn get_refund_for_put<T>(result: &NdResult<T>) -> Option<Coins> {
+    if result.is_err() {
+        Some(*COST_OF_PUT)
+    } else {
+        None
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,9 +79,9 @@ pub(crate) fn own_key(public_id: &PublicId) -> Option<&PublicKey> {
 /// Returns the requester's address.  An App's address is the name of its owner.
 pub(crate) fn requester_address(rpc: &Rpc) -> &XorName {
     match rpc {
-        Rpc::Request { ref requester, .. }
-        | Rpc::Response { ref requester, .. }
-        | Rpc::Refund { ref requester, .. } => requester.name(),
+        Rpc::Request { ref requester, .. } | Rpc::Response { ref requester, .. } => {
+            requester.name()
+        }
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -173,6 +173,14 @@ fn login_packets() {
         NdError::LoginPacketExists,
     );
 
+    // The balance should be unchanged
+    common::send_request_expect_ok(
+        &mut env,
+        &mut client,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(1)),
+    );
+
     // Getting login packet from non-owning client should fail.
     {
         let mut client = env.new_connected_client();
@@ -248,6 +256,14 @@ fn create_login_packet_for_other() {
             new_login_packet: login_packet.clone(),
         },
         NdError::BalanceExists,
+    );
+
+    // The balance should remain unchanged
+    common::send_request_expect_ok(
+        &mut env,
+        &mut established_client,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(start_nano - nano_to_transfer)),
     );
 
     // Getting login packet from non-owning client should fail.
@@ -719,6 +735,9 @@ fn put_append_only_data() {
         Request::PutAData(unpub_unseq_adata.clone()),
     );
 
+    let balance_a = unwrap!(Coins::from_nano(start_nano - 4));
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+
     // Get the data to verify
     common::send_request_expect_ok(
         &mut env,
@@ -795,6 +814,9 @@ fn put_append_only_data() {
         Request::DeleteAData(*unpub_unseq_adata.address()),
     );
 
+    // Deletions are free so A's balance should remain the same.
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+
     // Delete again to test if it's gone
     common::send_request_expect_err(
         &mut env,
@@ -808,6 +830,9 @@ fn put_append_only_data() {
         Request::DeleteAData(*unpub_unseq_adata.address()),
         NdError::NoSuchData,
     );
+
+    // The balance should remain the same when deletion fails
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
 }
 
 #[test]
@@ -846,6 +871,13 @@ fn delete_append_only_data_that_doesnt_exist() {
             *AData::UnpubUnseq(UnpubUnseqAppendOnlyData::new(name, tag)).address(),
         ),
         NdError::NoSuchData,
+    );
+
+    common::send_request_expect_ok(
+        &mut env,
+        &mut client,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(start_nano)),
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1959,7 +1959,6 @@ fn put_immutable_data() {
     );
 
     expected_a = unwrap!(expected_a.checked_sub(*COST_OF_PUT));
-    expected_b = unwrap!(expected_b.checked_sub(*COST_OF_PUT));
     common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, expected_a);
     common::send_request_expect_ok(&mut env, &mut client_b, Request::GetBalance, expected_b);
 }


### PR DESCRIPTION
Rebased against #874

resolves #873 

Todo:
- [x] See if refunds for transfer coins and create balance can be handled using the same pattern, thus deprecating `Rpc::Refund`
- [x] Add more tests