### PR TITLE
chore/lint: forbid unsafe and add badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
+    - RUSTFLAGS="-D warnings"
 language: rust
 rust: stable
 branches:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safe-nd"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1618,7 +1618,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "self_update 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2580,7 +2580,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f271e3552cd835fa28c541c34a7e8fdd8cdff09d77fe4eb8f6c42e87a11b096e"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum safe-nd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d0a69e37aa926cfad59c06dd90ba1f4b7bcceb738ef577aa24f83e6d8da6217"
+"checksum safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a3e30058c32d76a167a1e081837d105ac878d35ef5abe490dd7cf8c8055b9720"
 "checksum safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b08423011dae9a5ca23f07cf57dac3857f5c885d352b76f6d95f4aea9434d0"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ pickledb = "~0.4.0"
 quic-p2p = { version = "~0.2.1", optional = true }
 quick-error = "~1.2.2"
 rand = "~0.6.5"
-safe-nd = "~0.3.1"
+safe-nd = "~0.4.0"
 self_update = "0.5.1"
 serde = { version = "~1.0.97", features = ["derive"] }
 serde_json = "~1.0.40"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SAFE Vault
 
-|Crate|Documentation|Linux/macOS|Windows|
-|:---:|:-----------:|:---------:|:-----:|
-|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![Build Status](https://travis-ci.com/maidsafe/safe_vault.svg?branch=master)](https://travis-ci.com/maidsafe/safe_vault)|[![Build status](https://ci.appveyor.com/api/projects/status/ohu678c6ufw8b2bn/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-vault/branch/master)|
+|Crate|Documentation|Linux/macOS|Windows|Safe Rust|
+|:---:|:-----------:|:---------:|:-----:|:-------:|
+|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![Build Status](https://travis-ci.com/maidsafe/safe_vault.svg?branch=master)](https://travis-ci.com/maidsafe/safe_vault)|[![Build status](https://ci.appveyor.com/api/projects/status/ohu678c6ufw8b2bn/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-vault/branch/master)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|

--- a/src/action.rs
+++ b/src/action.rs
@@ -15,11 +15,11 @@ use std::collections::BTreeSet;
 pub(crate) enum Action {
     // Send a validated client request from client handlers to the appropriate destination.
     ForwardClientRequest(Rpc),
-    // Send a request from client handlers of Client A to Client B to then be handled as if Client B
-    // had made the request.  Only used by `CreateLoginPacketFor`, where Client A is creating the
-    // new balance for Client B, but also effectively bundles B's `CreateLoginPacket` with it.
+    /// Send a request from client handlers of Client A to Client B to then be handled as if Client
+    /// B had made the request. Only used by `CreateLoginPacketFor`, where Client A is creating the
+    /// new balance for Client B, but also effectively bundles B's `CreateLoginPacket` with it.
     ProxyClientRequest(Rpc),
-    // Send a response as an adult or elder to own section's elders.
+    /// Send a response as an adult or elder to own section's elders.
     RespondToOurDataHandlers {
         sender: XorName,
         rpc: Rpc,
@@ -28,7 +28,7 @@ pub(crate) enum Action {
         sender: XorName,
         rpc: Rpc,
     },
-    // Send the same request to each individual peer (used to send IData requests to adults).
+    /// Send the same request to each individual peer (used to send IData requests to adults).
     SendToPeers {
         sender: XorName,
         targets: BTreeSet<XorName>,

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -14,48 +14,17 @@
     html_favicon_url = "https://maidsafe.net/img/favicon.ico",
     test(attr(forbid(warnings)))
 )]
-// For explanation of lint checks, run `rustc -W help` or see
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    bad_style,
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_debug_implementations,
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     unused_results
-)]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
 )]
 
 fn main() {

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -15,7 +15,7 @@
     test(attr(forbid(warnings)))
 )]
 // For explanation of lint checks, run `rustc -W help`.
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -741,13 +741,6 @@ impl ClientHandler {
                 }
                 self.handle_response(src, requester, response, message_id)
             }
-            Rpc::Refund {
-                requester,
-                amount,
-                transaction_id,
-                reason,
-                message_id,
-            } => self.handle_refund(src, requester, amount, transaction_id, reason, message_id),
         }
     }
 
@@ -914,26 +907,6 @@ impl ClientHandler {
         }
     }
 
-    fn handle_refund(
-        &mut self,
-        _src: XorName,
-        requester: PublicId,
-        amount: Coins,
-        _transaction_id: TransactionId,
-        reason: NdError,
-        message_id: MessageId,
-    ) -> Option<Action> {
-        if let Err(error) = self.deposit(requester.name(), amount) {
-            error!(
-                "{}: Failed to refund {} coins for {:?}: {:?}",
-                self, amount, requester, error,
-            )
-        }
-
-        self.send_response_to_client(&requester, message_id, Response::Transaction(Err(reason)));
-        None
-    }
-
     fn handle_create_balance_client_req(
         &mut self,
         requester: &PublicId,
@@ -991,7 +964,7 @@ impl ClientHandler {
         transaction_id: TransactionId,
         message_id: MessageId,
     ) -> Option<Action> {
-        let rpc = match self.create_balance(&requester, owner_key, amount) {
+        let (result, refund) = match self.create_balance(&requester, owner_key, amount) {
             Ok(()) => {
                 let destination = XorName::from(owner_key);
                 let transaction = Transaction {
@@ -999,30 +972,23 @@ impl ClientHandler {
                     amount,
                 };
                 self.notify_destination_owners(&destination, transaction);
-                Rpc::Response {
-                    response: Response::Transaction(Ok(transaction)),
-                    requester,
-                    message_id,
-                    // TODO: Can we handle refund here instead of Rpc::Refund ?
-                    refund: None,
-                }
+                (Ok(transaction), None)
             }
             Err(error) => {
+                // Refund amount (Including the cost of creating a balance)
                 let amount = amount.checked_add(*COST_OF_PUT)?;
-                // Send refund. (Including the cost of creating a balance)
-                Rpc::Refund {
-                    requester,
-                    amount,
-                    transaction_id,
-                    reason: error,
-                    message_id,
-                }
+                (Err(error), Some(amount))
             }
         };
 
         Some(Action::RespondToClientHandlers {
             sender: *self.id.name(),
-            rpc,
+            rpc: Rpc::Response {
+                response: Response::Transaction(result),
+                requester,
+                message_id,
+                refund,
+            },
         })
     }
 
@@ -1063,7 +1029,7 @@ impl ClientHandler {
         transaction_id: TransactionId,
         message_id: MessageId,
     ) -> Option<Action> {
-        let rpc = match self.deposit(&destination, amount) {
+        let (result, refund) = match self.deposit(&destination, amount) {
             Ok(()) => {
                 let transaction = Transaction {
                     id: transaction_id,
@@ -1071,30 +1037,19 @@ impl ClientHandler {
                 };
 
                 self.notify_destination_owners(&destination, transaction);
-
-                Rpc::Response {
-                    response: Response::Transaction(Ok(transaction)),
-                    requester,
-                    message_id,
-                    // TODO: Can we handle refund here instead of Rpc::Refund ?
-                    refund: None,
-                }
+                (Ok(transaction), None)
             }
-            Err(error) => {
-                // Send refund
-                Rpc::Refund {
-                    requester,
-                    amount,
-                    transaction_id,
-                    reason: error,
-                    message_id,
-                }
-            }
+            Err(error) => (Err(error), Some(amount)),
         };
 
         Some(Action::RespondToClientHandlers {
             sender: *self.id.name(),
-            rpc,
+            rpc: Rpc::Response {
+                response: Response::Transaction(result),
+                requester,
+                message_id,
+                refund,
+            },
         })
     }
 
@@ -1383,17 +1338,19 @@ impl ClientHandler {
     ) -> Option<Action> {
         if &src == payer.name() {
             // Step two - create balance and forward login_packet.
-            //
-            // TODO: confirm this follows the same failure flow as CreateBalance request.
             if let Err(error) = self.create_balance(&payer, new_owner, amount) {
+                // Refund amount (Including the cost of creating the balance)
+                let refund = Some(amount.checked_add(*COST_OF_PUT)?);
+
                 Some(Action::RespondToClientHandlers {
                     sender: XorName::from(new_owner),
                     rpc: Rpc::Response {
                         response: Response::Transaction(Err(error)),
                         requester: payer,
                         message_id,
-                        // TODO: Refund here?
-                        refund: None,
+                        // TODO: Does CreateLoginPacketFor charge
+                        // for creation of balance *and* login packet ?
+                        refund,
                     },
                 })
             } else {

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -1525,8 +1525,9 @@ impl ClientHandler {
     ) -> Option<()> {
         let signature_required = match utils::authorisation_kind(request) {
             AuthorisationKind::GetUnpub
+            | AuthorisationKind::GetBalance
             | AuthorisationKind::Mut
-            | AuthorisationKind::GetBalance => true,
+            | AuthorisationKind::ManageAppKeys => true,
             AuthorisationKind::GetPub => false,
         };
 
@@ -1578,6 +1579,7 @@ impl ClientHandler {
             AuthorisationKind::Mut => {
                 self.check_app_permissions(app_id, |perms| perms.transfer_coins)
             }
+            AuthorisationKind::ManageAppKeys => Err(NdError::AccessDenied),
         };
 
         if let Err(error) = result {

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -1528,7 +1528,9 @@ impl ClientHandler {
         let signature_required = match utils::authorisation_kind(request) {
             AuthorisationKind::GetUnpub
             | AuthorisationKind::GetBalance
+            | AuthorisationKind::TransferCoins
             | AuthorisationKind::Mut
+            | AuthorisationKind::MutAndTransferCoins
             | AuthorisationKind::ManageAppKeys => true,
             AuthorisationKind::GetPub => false,
         };
@@ -1575,12 +1577,17 @@ impl ClientHandler {
             AuthorisationKind::GetPub => Ok(()),
             AuthorisationKind::GetUnpub => self.check_app_permissions(app_id, |_| true),
             AuthorisationKind::GetBalance => {
-                // TODO: Check `get_balance` instead of `transfer_coins` here, when it is implemented.
-                self.check_app_permissions(app_id, |perms| perms.transfer_coins)
+                self.check_app_permissions(app_id, |perms| perms.get_balance)
             }
             AuthorisationKind::Mut => {
+                self.check_app_permissions(app_id, |perms| perms.perform_mutations)
+            }
+            AuthorisationKind::TransferCoins => {
                 self.check_app_permissions(app_id, |perms| perms.transfer_coins)
             }
+            AuthorisationKind::MutAndTransferCoins => self.check_app_permissions(app_id, |perms| {
+                perms.transfer_coins && perms.perform_mutations
+            }),
             AuthorisationKind::ManageAppKeys => Err(NdError::AccessDenied),
         };
 

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -71,11 +71,13 @@ impl ClientHandler {
         total_used_space: &Rc<Cell<u64>>,
         init_mode: Init,
     ) -> Result<(Self, Receiver<Event>)> {
-        let auth_keys = AuthKeysDb::new(config.root_dir(), init_mode)?;
-        let balances = BalancesDb::new(config.root_dir(), init_mode)?;
+        let root_dir = config.root_dir()?;
+        let root_dir = root_dir.as_path();
+        let auth_keys = AuthKeysDb::new(root_dir, init_mode)?;
+        let balances = BalancesDb::new(root_dir, init_mode)?;
         let (quic_p2p, event_receiver) = Self::setup_quic_p2p(config.quic_p2p_config())?;
         let login_packets = LoginPacketChunkStore::new(
-            config.root_dir(),
+            root_dir,
             config.max_capacity(),
             Rc::clone(&total_used_space),
             init_mode,

--- a/src/data_handler.rs
+++ b/src/data_handler.rs
@@ -16,7 +16,7 @@ use crate::{action::Action, rpc::Rpc, vault::Init, Config, Result};
 use adata_handler::ADataHandler;
 use idata_handler::IDataHandler;
 use idata_holder::IDataHolder;
-use idata_op::{IDataOp, OpType};
+use idata_op::{IDataOp, IDataRequest, OpType};
 use log::{error, trace};
 use mdata_handler::MDataHandler;
 
@@ -376,8 +376,9 @@ impl DataHandler {
         message_id: MessageId,
     ) -> Option<Action> {
         if &src == address.name() {
-            // Since the src is the chunk's name, this message was sent by the data handlers to us as a
-            // single data handler, implying that we're a data handler where the chunk is stored.
+            // Since the src is the chunk's name, this message was sent by the data handlers to us
+            // as a single data handler, implying that we're a data handler where the chunk is
+            // stored.
             let client = self.client_id(&message_id)?.clone();
             self.idata_holder
                 .delete_unpub_idata(address, client, message_id)
@@ -396,8 +397,8 @@ impl DataHandler {
         message_id: MessageId,
     ) -> Option<Action> {
         if &src == address.name() {
-            // The message was sent by the data handlers to us as the one who is supposed to store the
-            // chunk. See the sent Get request below.
+            // The message was sent by the data handlers to us as the one who is supposed to store
+            // the chunk. See the sent Get request below.
             let client = self.client_id(&message_id)?.clone();
             self.idata_holder.get_idata(address, client, message_id)
         } else {

--- a/src/data_handler.rs
+++ b/src/data_handler.rs
@@ -68,10 +68,6 @@ impl DataHandler {
                 message_id,
                 ..
             } => self.handle_response(src, response, message_id),
-            _ => {
-                error!("{}: Received invalid vault RPC: {:?}", self, rpc);
-                None
-            }
         }
     }
 

--- a/src/data_handler.rs
+++ b/src/data_handler.rs
@@ -95,7 +95,7 @@ impl DataHandler {
             //
             // ===== Immutable Data =====
             //
-            PutIData(kind) => self.handle_put_idata_req(src, requester, kind, message_id),
+            PutIData(data) => self.handle_put_idata_req(src, requester, data, message_id),
             GetIData(address) => self.handle_get_idata_req(src, requester, address, message_id),
             DeleteUnpubIData(address) => {
                 self.handle_delete_unpub_idata_req(src, requester, address, message_id)
@@ -354,17 +354,17 @@ impl DataHandler {
         &mut self,
         src: XorName,
         requester: PublicId,
-        kind: IData,
+        data: IData,
         message_id: MessageId,
     ) -> Option<Action> {
-        if &src == kind.name() {
+        if &src == data.name() {
             // Since the src is the chunk's name, this message was sent by the data handlers to us
             // as a single data handler, implying that we're a data handler chosen to store the
             // chunk.
-            self.idata_holder.store_idata(kind, requester, message_id)
+            self.idata_holder.store_idata(data, requester, message_id)
         } else {
             self.idata_handler
-                .handle_put_idata_req(requester, kind, message_id)
+                .handle_put_idata_req(requester, data, message_id)
         }
     }
 

--- a/src/data_handler/adata_handler.rs
+++ b/src/data_handler/adata_handler.rs
@@ -41,7 +41,7 @@ impl ADataHandler {
         total_used_space: &Rc<Cell<u64>>,
         init_mode: Init,
     ) -> Result<Self> {
-        let root_dir = config.root_dir();
+        let root_dir = config.root_dir()?;
         let max_capacity = config.max_capacity();
         let chunks = AppendOnlyChunkStore::new(
             &root_dir,

--- a/src/data_handler/adata_handler.rs
+++ b/src/data_handler/adata_handler.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, AppendOnlyChunkStore},
@@ -66,11 +65,7 @@ impl ADataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {
@@ -535,11 +530,7 @@ impl ADataHandler {
                     .put(&adata)
                     .map_err(|error| error.to_string().into())
             });
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {

--- a/src/data_handler/adata_handler.rs
+++ b/src/data_handler/adata_handler.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, AppendOnlyChunkStore},
@@ -65,12 +66,18 @@ impl ADataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -108,6 +115,8 @@ impl ADataHandler {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                // Deletion is free so no refund
+                refund: None,
             },
         })
     }
@@ -126,6 +135,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetAData(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -147,6 +157,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataShell(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -168,6 +179,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataRange(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -188,6 +200,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataIndices(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -208,6 +221,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataLastEntry(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -234,6 +248,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataOwners(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -256,6 +271,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetPubADataUserPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -278,6 +294,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetUnpubADataUserPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -310,6 +327,7 @@ impl ADataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -331,6 +349,7 @@ impl ADataHandler {
                 requester,
                 response: Response::GetADataValue(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -516,12 +535,18 @@ impl ADataHandler {
                     .put(&adata)
                     .map_err(|error| error.to_string().into())
             });
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {
                 requester: requester.clone(),
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }

--- a/src/data_handler/idata_handler.rs
+++ b/src/data_handler/idata_handler.rs
@@ -42,7 +42,7 @@ pub(super) struct IDataHandler {
 
 impl IDataHandler {
     pub(super) fn new(id: NodePublicId, config: &Config, init_mode: Init) -> Result<Self> {
-        let root_dir = config.root_dir();
+        let root_dir = config.root_dir()?;
         let metadata = utils::new_db(&root_dir, IMMUTABLE_META_DB_NAME, init_mode)?;
         let full_adults = utils::new_db(&root_dir, FULL_ADULTS_DB_NAME, init_mode)?;
 

--- a/src/data_handler/idata_handler.rs
+++ b/src/data_handler/idata_handler.rs
@@ -7,7 +7,6 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{IDataOp, IDataRequest, OpType};
-use crate::client_handler::COST_OF_PUT;
 use crate::{action::Action, rpc::Rpc, utils, vault::Init, Config, Result, ToDbKey};
 use log::{trace, warn};
 use pickledb::PickleDb;
@@ -65,11 +64,7 @@ impl IDataHandler {
 
         let client_id = requester.clone();
         let respond = |result: NdResult<()>| {
-            let refund = if result.is_err() {
-                Some(*COST_OF_PUT)
-            } else {
-                None
-            };
+            let refund = utils::get_refund_for_put(&result);
             Some(Action::RespondToClientHandlers {
                 sender: data_name,
                 rpc: Rpc::Response {

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -60,6 +60,7 @@ impl IDataHolder {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
+
         Some(Action::RespondToOurDataHandlers {
             sender: *self.id.name(),
             rpc: Rpc::Response {
@@ -91,6 +92,7 @@ impl IDataHolder {
                 }
                 _ => Ok(idata),
             });
+
         Some(Action::RespondToOurDataHandlers {
             sender: *self.id.name(),
             rpc: Rpc::Response {

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action, chunk_store::ImmutableChunkStore, rpc::Rpc, utils, vault::Init, Config, Result,
 };
@@ -61,11 +60,7 @@ impl IDataHolder {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToOurDataHandlers {
             sender: *self.id.name(),
             rpc: Rpc::Response {

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -44,20 +44,20 @@ impl IDataHolder {
 
     pub(super) fn store_idata(
         &mut self,
-        kind: IData,
+        data: IData,
         requester: PublicId,
         message_id: MessageId,
     ) -> Option<Action> {
-        let result = if self.chunks.has(kind.address()) {
+        let result = if self.chunks.has(data.address()) {
             info!(
                 "{}: Immutable chunk already exists, not storing: {:?}",
                 self,
-                kind.address()
+                data.address()
             );
             Ok(())
         } else {
             self.chunks
-                .put(&kind)
+                .put(&data)
                 .map_err(|error| error.to_string().into())
         };
         Some(Action::RespondToOurDataHandlers {
@@ -81,15 +81,15 @@ impl IDataHolder {
             .chunks
             .get(&address)
             .map_err(|error| error.to_string().into())
-            .and_then(|kind| match kind {
+            .and_then(|idata| match idata {
                 IData::Unpub(ref data) => {
                     if data.owner() != client_pk {
                         Err(NdError::AccessDenied)
                     } else {
-                        Ok(kind)
+                        Ok(idata)
                     }
                 }
-                _ => Ok(kind),
+                _ => Ok(idata),
             });
         Some(Action::RespondToOurDataHandlers {
             sender: *self.id.name(),
@@ -114,7 +114,7 @@ impl IDataHolder {
             .chunks
             .get(&address)
             .map_err(|error| error.to_string().into())
-            .and_then(|kind| match kind {
+            .and_then(|data| match data {
                 IData::Unpub(ref data) => {
                     if data.owner() != client_pk {
                         Err(NdError::AccessDenied)

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action, chunk_store::ImmutableChunkStore, rpc::Rpc, utils, vault::Init, Config, Result,
 };
@@ -60,13 +61,18 @@ impl IDataHolder {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToOurDataHandlers {
             sender: *self.id.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -99,6 +105,7 @@ impl IDataHolder {
                 requester: client.clone(),
                 response: Response::GetIData(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -144,6 +151,7 @@ impl IDataHolder {
                 requester: client.clone(),
                 response: Response::Mutation(result),
                 message_id,
+                refund: None,
             },
         })
     }

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -31,7 +31,7 @@ impl IDataHolder {
         total_used_space: &Rc<Cell<u64>>,
         init_mode: Init,
     ) -> Result<Self> {
-        let root_dir = config.root_dir();
+        let root_dir = config.root_dir()?;
         let max_capacity = config.max_capacity();
         let chunks = ImmutableChunkStore::new(
             &root_dir,

--- a/src/data_handler/idata_op.rs
+++ b/src/data_handler/idata_op.rs
@@ -175,6 +175,7 @@ impl IDataOp {
                     requester: self.client().clone(),
                     response,
                     message_id,
+                    refund: None,
                 },
             })
         }

--- a/src/data_handler/idata_op.rs
+++ b/src/data_handler/idata_op.rs
@@ -125,7 +125,7 @@ impl IDataOp {
         self.set_to_actioned(&sender, result.err(), own_id)?;
 
         match self.request {
-            Request::PutIData(ref kind) => Some(*kind.address()),
+            Request::PutIData(ref data) => Some(*data.address()),
             Request::DeleteUnpubIData(address) => Some(address),
             _ => None, // unreachable - we checked above
         }

--- a/src/data_handler/mdata_handler.rs
+++ b/src/data_handler/mdata_handler.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, MutableChunkStore},
@@ -107,11 +106,7 @@ impl MDataHandler {
                     .put(&mdata)
                     .map_err(|error| error.to_string().into())
             });
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {
@@ -137,11 +132,7 @@ impl MDataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
-        let refund = if result.is_err() {
-            Some(*COST_OF_PUT)
-        } else {
-            None
-        };
+        let refund = utils::get_refund_for_put(&result);
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {

--- a/src/data_handler/mdata_handler.rs
+++ b/src/data_handler/mdata_handler.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{
     action::Action,
     chunk_store::{error::Error as ChunkStoreError, MutableChunkStore},
@@ -106,13 +107,18 @@ impl MDataHandler {
                     .put(&mdata)
                     .map_err(|error| error.to_string().into())
             });
-
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *address.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -131,12 +137,18 @@ impl MDataHandler {
                 .put(&data)
                 .map_err(|error| error.to_string().into())
         };
+        let refund = if result.is_err() {
+            Some(*COST_OF_PUT)
+        } else {
+            None
+        };
         Some(Action::RespondToClientHandlers {
             sender: *data.name(),
             rpc: Rpc::Response {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                refund,
             },
         })
     }
@@ -170,6 +182,8 @@ impl MDataHandler {
                 requester,
                 response: Response::Mutation(result),
                 message_id,
+                // Deletion is free so no refund
+                refund: None,
             },
         })
     }
@@ -242,6 +256,7 @@ impl MDataHandler {
                 requester,
                 response: Response::GetMData(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -263,6 +278,7 @@ impl MDataHandler {
                 requester,
                 response: Response::GetMDataShell(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -284,6 +300,7 @@ impl MDataHandler {
                 requester,
                 response: Response::GetMDataVersion(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -319,6 +336,7 @@ impl MDataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -340,6 +358,7 @@ impl MDataHandler {
                 requester,
                 response: Response::ListMDataKeys(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -364,6 +383,7 @@ impl MDataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -388,6 +408,7 @@ impl MDataHandler {
                 requester,
                 response,
                 message_id,
+                refund: None,
             },
         })
     }
@@ -409,6 +430,7 @@ impl MDataHandler {
                 requester,
                 response: Response::ListMDataPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }
@@ -431,6 +453,7 @@ impl MDataHandler {
                 requester,
                 response: Response::ListMDataUserPermissions(result),
                 message_id,
+                refund: None,
             },
         })
     }

--- a/src/data_handler/mdata_handler.rs
+++ b/src/data_handler/mdata_handler.rs
@@ -39,7 +39,7 @@ impl MDataHandler {
         total_used_space: &Rc<Cell<u64>>,
         init_mode: Init,
     ) -> Result<Self> {
-        let root_dir = config.root_dir();
+        let root_dir = config.root_dir()?;
         let max_capacity = config.max_capacity();
         let chunks = MutableChunkStore::new(
             &root_dir,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,46 +13,18 @@
     html_favicon_url = "https://maidsafe.net/img/favicon.ico",
     test(attr(forbid(warnings)))
 )]
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    // TODO: add missing debug implementations for structs?
+    // missing_debug_implementations,
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     unused_results
-)]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
 )]
 // For quick_error
 #![recursion_limit = "128"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
     test(attr(forbid(warnings)))
 )]
 // For explanation of lint checks, run `rustc -W help`.
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(
     // TODO: add missing debug implementations for structs?
     // missing_debug_implementations,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -8,7 +8,7 @@
 
 //! RPC messages internal to Vaults.
 
-use safe_nd::{Coins, Error as NdError, MessageId, PublicId, Request, Response, TransactionId};
+use safe_nd::{Coins, MessageId, PublicId, Request, Response};
 use serde::{Deserialize, Serialize};
 
 /// RPC messages exchanged between nodes.
@@ -27,13 +27,5 @@ pub(crate) enum Rpc {
         requester: PublicId,
         message_id: MessageId,
         refund: Option<Coins>,
-    },
-    /// Refund for a failed coin transfer. Send between ClientHandlers.
-    Refund {
-        requester: PublicId,
-        amount: Coins,
-        transaction_id: TransactionId,
-        reason: NdError,
-        message_id: MessageId,
     },
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -26,6 +26,7 @@ pub(crate) enum Rpc {
         response: Response,
         requester: PublicId,
         message_id: MessageId,
+        refund: Option<Coins>,
     },
     /// Refund for a failed coin transfer. Send between ClientHandlers.
     Refund {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -151,6 +151,8 @@ pub(crate) enum AuthorisationKind {
     GetBalance,
     // Mutation request.
     Mut,
+    // Request to manage app keys.
+    ManageAppKeys,
 }
 
 // Returns the type of authorisation needed for the given request.
@@ -176,9 +178,7 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | CreateBalance { .. }
         | CreateLoginPacket(_)
         | CreateLoginPacketFor { .. }
-        | UpdateLoginPacket(_)
-        | InsAuthKey { .. }
-        | DelAuthKey { .. } => AuthorisationKind::Mut,
+        | UpdateLoginPacket(_) => AuthorisationKind::Mut,
         GetIData(IDataAddress::Pub(_)) => AuthorisationKind::GetPub,
         GetIData(IDataAddress::Unpub(_))
         | GetMData(_)
@@ -190,8 +190,7 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | ListMDataValues(_)
         | ListMDataPermissions(_)
         | ListMDataUserPermissions { .. }
-        | GetLoginPacket(_)
-        | ListAuthKeysAndVersion => AuthorisationKind::GetUnpub,
+        | GetLoginPacket(_) => AuthorisationKind::GetUnpub,
         GetAData(address)
         | GetADataValue { address, .. }
         | GetADataShell { address, .. }
@@ -209,5 +208,8 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
             }
         }
         GetBalance => AuthorisationKind::GetBalance,
+        ListAuthKeysAndVersion | InsAuthKey { .. } | DelAuthKey { .. } => {
+            AuthorisationKind::ManageAppKeys
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,12 +6,15 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::client_handler::COST_OF_PUT;
 use crate::{rpc::Rpc, vault::Init, Result};
 use bincode;
 use log::{error, trace};
 use pickledb::{PickleDb, PickleDbDumpPolicy};
 use rand::{distributions::Standard, thread_rng, Rng};
-use safe_nd::{ClientPublicId, IDataAddress, PublicId, PublicKey, Request, XorName};
+use safe_nd::{
+    ClientPublicId, Coins, IDataAddress, PublicId, PublicKey, Request, Result as NdResult, XorName,
+};
 use serde::Serialize;
 use std::{borrow::Cow, fs, path::Path};
 use unwrap::unwrap;
@@ -220,5 +223,13 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         ListAuthKeysAndVersion | InsAuthKey { .. } | DelAuthKey { .. } => {
             AuthorisationKind::ManageAppKeys
         }
+    }
+}
+
+pub(crate) fn get_refund_for_put<T>(result: &NdResult<T>) -> Option<Coins> {
+    if result.is_err() {
+        Some(*COST_OF_PUT)
+    } else {
+        None
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,9 +79,9 @@ pub(crate) fn own_key(public_id: &PublicId) -> Option<&PublicKey> {
 /// Returns the requester's address.  An App's address is the name of its owner.
 pub(crate) fn requester_address(rpc: &Rpc) -> &XorName {
     match rpc {
-        Rpc::Request { ref requester, .. }
-        | Rpc::Response { ref requester, .. }
-        | Rpc::Refund { ref requester, .. } => requester.name(),
+        Rpc::Request { ref requester, .. } | Rpc::Response { ref requester, .. } => {
+            requester.name()
+        }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,6 +153,10 @@ pub(crate) enum AuthorisationKind {
     Mut,
     // Request to manage app keys.
     ManageAppKeys,
+    // Request to transfer coins
+    TransferCoins,
+    // Request to mutate and transfer coins
+    MutAndTransferCoins,
 }
 
 // Returns the type of authorisation needed for the given request.
@@ -174,11 +178,16 @@ pub(crate) fn authorisation_kind(request: &Request) -> AuthorisationKind {
         | SetADataOwner { .. }
         | AppendSeq { .. }
         | AppendUnseq(_)
-        | TransferCoins { .. }
-        | CreateBalance { .. }
         | CreateLoginPacket(_)
-        | CreateLoginPacketFor { .. }
         | UpdateLoginPacket(_) => AuthorisationKind::Mut,
+        CreateBalance { amount, .. } | CreateLoginPacketFor { amount, .. } => {
+            if amount.as_nano() == 0 {
+                AuthorisationKind::Mut
+            } else {
+                AuthorisationKind::MutAndTransferCoins
+            }
+        }
+        TransferCoins { .. } => AuthorisationKind::TransferCoins,
         GetIData(IDataAddress::Pub(_)) => AuthorisationKind::GetPub,
         GetIData(IDataAddress::Unpub(_))
         | GetMData(_)

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -75,6 +75,9 @@ impl Vault {
             (true, id)
         });
 
+        let root_dir = config.root_dir()?;
+        let root_dir = root_dir.as_path();
+
         let (state, event_receiver) = if is_elder {
             let total_used_space = Rc::new(Cell::new(0));
             let (client_handler, event_receiver) = ClientHandler::new(
@@ -89,8 +92,7 @@ impl Vault {
                 &total_used_space,
                 init_mode,
             )?;
-            let coins_handler =
-                CoinsHandler::new(id.public_id().clone(), config.root_dir(), init_mode)?;
+            let coins_handler = CoinsHandler::new(id.public_id().clone(), root_dir, init_mode)?;
             (
                 State::Elder {
                     client_handler,
@@ -102,7 +104,7 @@ impl Vault {
         } else {
             let _adult = Adult::new(
                 id.public_id().clone(),
-                config.root_dir(),
+                root_dir,
                 config.max_capacity(),
                 init_mode,
             )?;
@@ -111,7 +113,7 @@ impl Vault {
 
         let vault = Self {
             id,
-            root_dir: config.root_dir().to_path_buf(),
+            root_dir: root_dir.to_path_buf(),
             state,
             event_receiver,
             command_receiver,
@@ -421,7 +423,7 @@ impl Vault {
 
     /// Returns Some((is_elder, ID)) or None if file doesn't exist.
     fn read_state(config: &Config) -> Result<Option<(bool, NodeFullId)>> {
-        let path = config.root_dir().join(STATE_FILENAME);
+        let path = config.root_dir()?.join(STATE_FILENAME);
         if !path.is_file() {
             return Ok(None);
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -486,16 +486,6 @@ pub fn send_request_expect_err<T: TestClientTrait>(
     assert_eq!(expected_response, client.expect_response(message_id));
 }
 
-pub fn send_request_expect_no_response<T: TestClientTrait>(
-    env: &mut Environment,
-    client: &mut T,
-    request: Request,
-) {
-    let _message_id = client.send_request(request);
-    env.poll();
-    client.expect_no_new_message();
-}
-
 pub fn create_balance(
     env: &mut Environment,
     src_client: &mut TestClient,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2248,14 +2248,28 @@ fn auth_keys() {
     list_keys(&mut env, &mut owner, Ok((expected_map.clone(), 1)));
 
     // Check the app isn't allowed to get a listing of authorised keys, nor insert, nor delete any.
-    // No response should be returned to any of these requests.
-    common::send_request_expect_no_response(&mut env, &mut app, Request::ListAuthKeysAndVersion);
-    common::send_request_expect_no_response(&mut env, &mut app, make_ins_request(2));
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        Request::ListAuthKeysAndVersion,
+        NdError::AccessDenied,
+    );
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        make_ins_request(2),
+        NdError::AccessDenied,
+    );
     let del_auth_key_request = Request::DelAuthKey {
         key: *app.public_id().public_key(),
         version: 2,
     };
-    common::send_request_expect_no_response(&mut env, &mut app, del_auth_key_request.clone());
+    common::send_request_expect_err(
+        &mut env,
+        &mut app,
+        del_auth_key_request.clone(),
+        NdError::AccessDenied,
+    );
 
     // Remove the app, then list the keys.
     common::perform_mutation(&mut env, &mut owner, del_auth_key_request);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -173,6 +173,14 @@ fn login_packets() {
         NdError::LoginPacketExists,
     );
 
+    // The balance should be unchanged
+    common::send_request_expect_ok(
+        &mut env,
+        &mut client,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(1)),
+    );
+
     // Getting login packet from non-owning client should fail.
     {
         let mut client = env.new_connected_client();
@@ -248,6 +256,14 @@ fn create_login_packet_for_other() {
             new_login_packet: login_packet.clone(),
         },
         NdError::BalanceExists,
+    );
+
+    // The balance should remain unchanged
+    common::send_request_expect_ok(
+        &mut env,
+        &mut established_client,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(start_nano - nano_to_transfer)),
     );
 
     // Getting login packet from non-owning client should fail.
@@ -719,6 +735,9 @@ fn put_append_only_data() {
         Request::PutAData(unpub_unseq_adata.clone()),
     );
 
+    let balance_a = unwrap!(Coins::from_nano(start_nano - 4));
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+
     // Get the data to verify
     common::send_request_expect_ok(
         &mut env,
@@ -795,6 +814,9 @@ fn put_append_only_data() {
         Request::DeleteAData(*unpub_unseq_adata.address()),
     );
 
+    // Deletions are free so A's balance should remain the same.
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
+
     // Delete again to test if it's gone
     common::send_request_expect_err(
         &mut env,
@@ -808,6 +830,9 @@ fn put_append_only_data() {
         Request::DeleteAData(*unpub_unseq_adata.address()),
         NdError::NoSuchData,
     );
+
+    // The balance should remain the same when deletion fails
+    common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);
 }
 
 #[test]
@@ -846,6 +871,13 @@ fn delete_append_only_data_that_doesnt_exist() {
             *AData::UnpubUnseq(UnpubUnseqAppendOnlyData::new(name, tag)).address(),
         ),
         NdError::NoSuchData,
+    );
+
+    common::send_request_expect_ok(
+        &mut env,
+        &mut client,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(start_nano)),
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,46 +8,17 @@
 
 // TODO: make these tests work without mock too.
 #![cfg(feature = "mock")]
-#![forbid(
-    exceeding_bitshifts,
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
-#![deny(
-    bad_style,
-    deprecated,
-    improper_ctypes,
-    missing_docs,
-    non_shorthand_field_patterns,
-    overflowing_literals,
-    plugin_as_library,
-    stable_features,
-    unconditional_recursion,
-    unknown_lints,
-    unsafe_code,
-    unused,
-    unused_allocation,
-    unused_attributes,
-    unused_comparisons,
-    unused_features,
-    unused_parens,
-    while_true
-)]
+// For explanation of lint checks, run `rustc -W help`.
+#![deny(unsafe_code)]
 #![warn(
+    missing_debug_implementations,
+    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     unused_results
-)]
-#![allow(
-    box_pointers,
-    missing_copy_implementations,
-    missing_debug_implementations,
-    variant_size_differences
 )]
 
 #[macro_use]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -465,6 +465,8 @@ fn coin_operations_by_app() {
             version: 1,
             permissions: AppPermissions {
                 transfer_coins: true,
+                get_balance: true,
+                perform_mutations: true,
             },
         },
     );
@@ -519,7 +521,9 @@ fn coin_operations_by_app_with_insufficient_permissions() {
             key: *app.public_id().public_key(),
             version: 1,
             permissions: AppPermissions {
+                get_balance: false,
                 transfer_coins: false,
+                perform_mutations: false,
             },
         },
     );
@@ -2210,6 +2214,8 @@ fn auth_keys() {
 
     let permissions = AppPermissions {
         transfer_coins: true,
+        perform_mutations: true,
+        get_balance: true,
     };
     let app_public_key = *app.public_id().public_key();
     let make_ins_request = |version| Request::InsAuthKey {
@@ -2306,7 +2312,9 @@ fn app_permissions() {
             key: *app_0.public_id().public_key(),
             version: 1,
             permissions: AppPermissions {
-                transfer_coins: true,
+                perform_mutations: true,
+                get_balance: false,
+                transfer_coins: false,
             },
         },
     );
@@ -2322,6 +2330,8 @@ fn app_permissions() {
             version: 2,
             permissions: AppPermissions {
                 transfer_coins: false,
+                get_balance: false,
+                perform_mutations: false,
             },
         },
     );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1959,7 +1959,6 @@ fn put_immutable_data() {
     );
 
     expected_a = unwrap!(expected_a.checked_sub(*COST_OF_PUT));
-    expected_b = unwrap!(expected_b.checked_sub(*COST_OF_PUT));
     common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, expected_a);
     common::send_request_expect_ok(&mut env, &mut client_b, Request::GetBalance, expected_b);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,7 +9,7 @@
 // TODO: make these tests work without mock too.
 #![cfg(feature = "mock")]
 // For explanation of lint checks, run `rustc -W help`.
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
I noticed that `unsafe_code` can actually be `forbid` (which is stronger than `deny`), since we don't use any unsafe code in this crate! So I changed it and added the `unsafe forbidden` badge.