### PR TITLE
chore/lint: forbid unsafe and add badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SAFE Vault
 
-|Crate|Documentation|Linux/macOS|Windows|
-|:---:|:-----------:|:---------:|:-----:|
-|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![Build Status](https://travis-ci.com/maidsafe/safe_vault.svg?branch=master)](https://travis-ci.com/maidsafe/safe_vault)|[![Build status](https://ci.appveyor.com/api/projects/status/ohu678c6ufw8b2bn/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-vault/branch/master)|
+|Crate|Documentation|Linux/macOS|Windows|Safe Rust|
+|:---:|:-----------:|:---------:|:-----:|:-------:|
+|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![Build Status](https://travis-ci.com/maidsafe/safe_vault.svg?branch=master)](https://travis-ci.com/maidsafe/safe_vault)|[![Build status](https://ci.appveyor.com/api/projects/status/ohu678c6ufw8b2bn/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-vault/branch/master)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -15,7 +15,7 @@
     test(attr(forbid(warnings)))
 )]
 // For explanation of lint checks, run `rustc -W help`.
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
     test(attr(forbid(warnings)))
 )]
 // For explanation of lint checks, run `rustc -W help`.
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(
     // TODO: add missing debug implementations for structs?
     // missing_debug_implementations,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,7 +9,7 @@
 // TODO: make these tests work without mock too.
 #![cfg(feature = "mock")]
 // For explanation of lint checks, run `rustc -W help`.
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
I noticed that `unsafe_code` can actually be `forbid` (which is stronger than `deny`), since we don't use any unsafe code in this crate! So I changed it and added the `unsafe forbidden` badge.