### PR TITLE
Remove refund for `LoginPacketExists` errors

### DIFF
--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -1377,14 +1377,15 @@ impl ClientHandler {
                     })
                     .map_err(|error| error.to_string().into())
             };
-            let refund = utils::get_refund_for_put(&result);
             Some(Action::RespondToClientHandlers {
                 sender: *login_packet.destination(),
                 rpc: Rpc::Response {
                     response: Response::Transaction(result),
                     requester: payer,
                     message_id,
-                    refund,
+                    // A new balance is already created as
+                    // a part of the flow. So no refund is processed.
+                    refund: None,
                 },
             })
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -169,6 +169,7 @@ fn create_login_packet_for_other() {
     let mut env = Environment::new();
     let mut established_client = env.new_connected_client();
     let mut new_client = env.new_connected_client();
+    let mut new_client2 = env.new_connected_client();
 
     let login_packet_data = vec![0; 32];
     let login_packet_locator: XorName = env.rng().gen();
@@ -235,6 +236,31 @@ fn create_login_packet_for_other() {
         &mut established_client,
         Request::GetBalance,
         unwrap!(Coins::from_nano(start_nano - nano_to_transfer)),
+    );
+
+    // Putting login packet to the same address with different balance should fail
+    // with `LoginPacketExists`
+    common::send_request_expect_err(
+        &mut env,
+        &mut established_client,
+        Request::CreateLoginPacketFor {
+            new_owner: *new_client2.public_id().public_key(),
+            amount,
+            transaction_id: 3,
+            new_login_packet: login_packet.clone(),
+        },
+        NdError::LoginPacketExists,
+    );
+
+    // The new balance should be created
+    common::send_request_expect_ok(&mut env, &mut new_client2, Request::GetBalance, amount);
+
+    // The client's balance should be updated
+    common::send_request_expect_ok(
+        &mut env,
+        &mut established_client,
+        Request::GetBalance,
+        unwrap!(Coins::from_nano(start_nano - 2 * nano_to_transfer)),
     );
 
     // Getting login packet from non-owning client should fail.


### PR DESCRIPTION
- The cost of `CreateLoginPacketFor` is only 1 PUT. In cases where the
request creates the new balance successfully, but, fails at the stage
where the login packet is inserted, the client should not be refunded. A
refund in this situation would allow clients to create unlimited number
of balances without spending any coins. This could lead to a potential
spam attack.