### PR TITLE
feat/vault: add --dump-completions flag similar to that of safe-cli

### DIFF
--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -192,13 +192,23 @@ mod detail {
         // get filename without preceding path as std::ffi::OsStr (C string)
         let exec_name_ffi = match exe_path.file_name() {
             Some(v) => v,
-            None => return Err(format!("Can't extract file_name of executable from path {}", exe_path.display())),
+            None => {
+                return Err(format!(
+                    "Can't extract file_name of executable from path {}",
+                    exe_path.display()
+                ))
+            }
         };
 
         // Convert OsStr to string.  Can fail if OsStr contains any invalid unicode.
         let exec_name = match exec_name_ffi.to_str() {
             Some(v) => v.to_string(),
-            None => return Err(format!("Can't decode unicode in executable name '{:?}'", exec_name_ffi)),
+            None => {
+                return Err(format!(
+                    "Can't decode unicode in executable name '{:?}'",
+                    exec_name_ffi
+                ))
+            }
         };
 
         // Generates shell completions for <shell> and prints to stdout

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -192,13 +192,13 @@ mod detail {
         // get filename without preceding path as std::ffi::OsStr (C string)
         let exec_name_ffi = match exe_path.file_name() {
             Some(v) => v,
-            None => return Err("Can't extract file_name of executable".to_string()),
+            None => return Err(format!("Can't extract file_name of executable from path {}", exe_path.display())),
         };
 
         // Convert OsStr to string.  Can fail if OsStr contains any invalid unicode.
         let exec_name = match exec_name_ffi.to_str() {
             Some(v) => v.to_string(),
-            None => return Err("Can't decode unicode in executable name".to_string()),
+            None => return Err(format!("Can't decode unicode in executable name '{:?}'", exec_name_ffi)),
         };
 
         // Generates shell completions for <shell> and prints to stdout

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -46,7 +46,7 @@ mod detail {
     pub fn main() {
         let mut config = Config::new();
 
-        if let Some(c) = &config.dump_completions() {
+        if let Some(c) = &config.completions() {
             match c.parse::<clap::Shell>() {
                 Ok(shell) => match gen_completions_for_shell(shell) {
                     Ok(buf) => {
@@ -56,7 +56,7 @@ mod detail {
                     }
                     Err(e) => println!("{}", e),
                 },
-                Err(e) => println!("Unknown dump-completions option. {}", e),
+                Err(e) => println!("Unknown completions option. {}", e),
             }
             // we exit program on both success and error.
             return;

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -39,12 +39,29 @@ mod detail {
     use self_update::cargo_crate_version;
     use self_update::Status;
     use std::{io::Write, process};
-    use structopt::StructOpt;
+    use structopt::{clap, StructOpt};
     use unwrap::unwrap;
 
     /// Runs a SAFE Network vault.
     pub fn main() {
         let mut config = Config::new();
+
+        if let Some(c) = &config.dump_completions() {
+            match c.parse::<clap::Shell>() {
+                Ok(shell) => match gen_completions_for_shell(shell) {
+                    Ok(buf) => {
+                        std::io::stdout().write_all(&buf).unwrap_or_else(|e| {
+                            println!("Failed to print shell completions. {}", e);
+                        });
+                    }
+                    Err(e) => println!("{}", e),
+                },
+                Err(e) => println!("Unknown dump-completions option. {}", e),
+            }
+            // we exit program on both success and error.
+            return;
+        }
+
         if config.network_config().ip.is_none() {
             config.listen_on_loopback();
         }
@@ -165,6 +182,30 @@ mod detail {
         Ok(Status::UpToDate(
             "No releases are available for updates".to_string(),
         ))
+    }
+
+    fn gen_completions_for_shell(shell: clap::Shell) -> Result<Vec<u8>, String> {
+        // Get exe path
+        let exe_path =
+            std::env::current_exe().map_err(|err| format!("Can't get the exec path: {}", err))?;
+
+        // get filename without preceding path as std::ffi::OsStr (C string)
+        let exec_name_ffi = match exe_path.file_name() {
+            Some(v) => v,
+            None => return Err("Can't extract file_name of executable".to_string()),
+        };
+
+        // Convert OsStr to string.  Can fail if OsStr contains any invalid unicode.
+        let exec_name = match exec_name_ffi.to_str() {
+            Some(v) => v.to_string(),
+            None => return Err("Can't decode unicode in executable name".to_string()),
+        };
+
+        // Generates shell completions for <shell> and prints to stdout
+        let mut buf: Vec<u8> = vec![];
+        Config::clap().gen_completions_to(exec_name, shell, &mut buf);
+
+        Ok(buf)
     }
 }
 

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -359,6 +359,7 @@ mod test {
                 verbose: 0,
                 network_config: Default::default(),
                 first: false,
+                completions: None,
             };
             let empty_config = config.clone();
             if let Some(val) = matches.value_of(arg) {

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -50,7 +50,7 @@ const ARGS: [&str; 14] = [
     "our-complete-cert",
     "our-type",
     "first",
-    "dump-completions",
+    "completions",
 ];
 
 /// Vault configuration
@@ -83,8 +83,8 @@ pub struct Config {
     #[allow(missing_docs)]
     network_config: NetworkConfig,
     /// dump shell completions for: [bash, fish, zsh, powershell, elvish]
-    #[structopt(long = "dump-completions", raw(global = "true"))]
-    dump_completions: Option<String>,
+    #[structopt(long = "completions", raw(global = "true"))]
+    completions: Option<String>,
 }
 
 impl Config {
@@ -98,7 +98,7 @@ impl Config {
             verbose: 0,
             network_config: Default::default(),
             first: false,
-            dump_completions: None,
+            completions: None,
         });
 
         let command_line_args = Config::clap().get_matches();
@@ -167,9 +167,9 @@ impl Config {
         self.network_config = config;
     }
 
-    /// Get the dump-completions option
-    pub fn dump_completions(&self) -> &Option<String> {
-        &self.dump_completions
+    /// Get the completions option
+    pub fn completions(&self) -> &Option<String> {
+        &self.completions
     }
 
     /// Set the Quic-P2P `ip` configuration to 127.0.0.1.
@@ -195,7 +195,7 @@ impl Config {
         } else if arg == ARGS[11] {
             self.network_config.our_type = unwrap!(value.parse());
         } else if arg == ARGS[13] {
-            self.dump_completions = Some(unwrap!(value.parse()));
+            self.completions = Some(unwrap!(value.parse()));
         } else {
             #[cfg(not(feature = "mock"))]
             {

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -83,7 +83,7 @@ pub struct Config {
     #[allow(missing_docs)]
     network_config: NetworkConfig,
     /// dump shell completions for: [bash, fish, zsh, powershell, elvish]
-    #[structopt(long = "completions", raw(global = "true"))]
+    #[structopt(long)]
     completions: Option<String>,
 }
 
@@ -304,7 +304,7 @@ mod test {
     #[test]
     fn smoke() {
         let expected_size = if cfg!(target_pointer_width = "64") {
-            272
+            296
         } else {
             184
         };
@@ -339,6 +339,7 @@ mod test {
             ["our-complete-cert", &base64_certificate],
             ["our-type", "client"],
             ["first", "None"],
+            ["completions", "bash"],
         ];
 
         for arg in &ARGS {

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -36,7 +36,7 @@ const CONFIG_FILE: &str = "vault.config";
 const CONNECTION_INFO_FILE: &str = "vault_connection_info.config";
 const DEFAULT_ROOT_DIR_NAME: &str = "root_dir";
 const DEFAULT_MAX_CAPACITY: u64 = 2 * 1024 * 1024 * 1024;
-const ARGS: [&str; 13] = [
+const ARGS: [&str; 14] = [
     "wallet-address",
     "max-capacity",
     "root-dir",
@@ -50,6 +50,7 @@ const ARGS: [&str; 13] = [
     "our-complete-cert",
     "our-type",
     "first",
+    "dump-completions",
 ];
 
 /// Vault configuration
@@ -81,6 +82,9 @@ pub struct Config {
     #[structopt(flatten)]
     #[allow(missing_docs)]
     network_config: NetworkConfig,
+    /// dump shell completions for: [bash, fish, zsh, powershell, elvish]
+    #[structopt(long = "dump-completions", raw(global = "true"))]
+    dump_completions: Option<String>,
 }
 
 impl Config {
@@ -94,6 +98,7 @@ impl Config {
             verbose: 0,
             network_config: Default::default(),
             first: false,
+            dump_completions: None,
         });
 
         let command_line_args = Config::clap().get_matches();
@@ -162,6 +167,11 @@ impl Config {
         self.network_config = config;
     }
 
+    /// Get the dump-completions option
+    pub fn dump_completions(&self) -> &Option<String> {
+        &self.dump_completions
+    }
+
     /// Set the Quic-P2P `ip` configuration to 127.0.0.1.
     pub fn listen_on_loopback(&mut self) {
         self.network_config.ip = Some(IpAddr::V4(Ipv4Addr::LOCALHOST));
@@ -184,6 +194,8 @@ impl Config {
             self.network_config.ip = Some(unwrap!(value.parse()));
         } else if arg == ARGS[11] {
             self.network_config.our_type = unwrap!(value.parse());
+        } else if arg == ARGS[13] {
+            self.dump_completions = Some(unwrap!(value.parse()));
         } else {
             #[cfg(not(feature = "mock"))]
             {


### PR DESCRIPTION
hi, for your consideration -- I added a --completions option, ie:

```
$ safe_vault --help | grep dump
        --completions <completions>
            dump shell completions for: [bash, fish, zsh, powershell, elvish]
```

Example Usage:

```
$ safe_vault --completions bash > /tmp/vault_completions.sh
$ source /tmp/vault_completions.sh
$ safe_vault --<tab>
--bootstrap-cache-dir       --idle-timeout-msec         --our-complete-cert         --version
--dump-completions          --ip                        --our-type                  --wallet-address
--first                     --keep-alive-interval-msec  --port                      
--hard-coded-contacts       --max-capacity              --root-dir                  
--help                      --max-msg-size-allowed      --verbose 
$ safe_vault --max-<tab>
--max-capacity          --max-msg-size-allowed
```

This is similar in spirit to https://github.com/maidsafe/safe-api/pull/328, though that one is implemented as a subcommand and also has the capability to dump completions for all supported shells at once as json.

The general idea is to make it easy to enable shell completions for the various safe CLI apps, probably at install time.  

note: Since these completions are generated directly by clap/structopt, the output of --completions always remains in sync with the code. 