### PR TITLE
test/vault: use real routing for the integration test, with multiple vaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -273,7 +273,7 @@ dependencies = [
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -302,7 +302,7 @@ dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -478,7 +478,7 @@ dependencies = [
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -992,9 +992,9 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1028,7 +1028,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1263,7 +1263,7 @@ name = "num_cpus"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1361,8 +1361,8 @@ dependencies = [
  "maidsafe_utilities 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1406,7 +1406,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1468,7 +1468,7 @@ dependencies = [
 [[package]]
 name = "quic-p2p"
 version = "0.3.0"
-source = "git+https://github.com/maidsafe/quic-p2p#4b4d3b770f4e8867f0663299b55c90e98bc5a95b"
+source = "git+https://github.com/maidsafe/quic-p2p#444204cecbf1fffe39e25e04c1380d3e55ff4fea"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1480,8 +1480,8 @@ dependencies = [
  "quinn 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rcgen 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1838,7 +1838,7 @@ dependencies = [
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "routing"
 version = "0.37.0"
-source = "git+https://github.com/maidsafe/routing.git?branch=fleming#6bebd5b0cdf9c5fb3f632385ccab9325461f9c19"
+source = "git+https://github.com/maidsafe/routing.git?branch=fleming#860a666d4cb0b2d4d38520046d6d583520c12ddc"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1901,8 +1901,8 @@ dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource_proof 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1968,7 +1968,7 @@ dependencies = [
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2000,7 +2000,7 @@ dependencies = [
  "routing 0.37.0 (git+https://github.com/maidsafe/routing.git?branch=fleming)",
  "safe-nd 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "self_update 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2087,10 +2087,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2109,12 +2109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2129,7 +2129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2139,7 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2150,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2161,7 +2161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2382,7 +2382,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand04_compat 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2413,7 +2413,7 @@ dependencies = [
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2601,7 +2601,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2999,7 +2999,7 @@ dependencies = [
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum half 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ff54597ea139063f4225f1ec47011b03c9de4a486957ff3fc506881dac951d0"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+"checksum hermit-abi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex_fmt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "879eb6cb1d33ed9e8926ee5db25db12acead81020c991009f41a934364fb04da"
@@ -3136,10 +3136,10 @@ dependencies = [
 "checksum self_update 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e4997d828329f3bea234b5efd084f0ee07b284a556d64023cc0e3e47cc44d74"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
+"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 "checksum serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45cd6d95391b16cd57e88b68be41d504183b7faae22030c0cc3b3f73dd57b2fd"
-"checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
+"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,7 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake_clock 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crossbeam-channel = "~0.3.8"
 ctrlc = "~3.1.3"
 directories = "~2.0.1"
 env_logger = "~0.6.2"
+fake_clock = "~0.3.0"
 fxhash = { version = "~0.2.1", optional = true }
 hex = "~0.3.2"
 hex_fmt = { version = "~0.3.0", optional = true }
@@ -47,4 +48,5 @@ doc = false
 
 [features]
 mock = ["routing/mock_base", "fxhash", "hex_fmt"]
+mock-parsec = ["routing/mock_parsec", "routing/mock_crypto", "fxhash", "hex_fmt", "phase-one"]
 phase-one = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "~0.4.7"
 pickledb = "~0.4.0"
 quick-error = "~1.2.2"
 rand = "~0.6.5"
+rand_chacha = "~0.1.1"
 routing = { git = "https://github.com/maidsafe/routing.git", branch = "fleming" }
 safe-nd = "~0.7.0"
 self_update = "0.5.1"
@@ -39,7 +40,6 @@ unwrap = "~1.2.1"
 
 [dev_dependencies]
 maplit = "~1.0.1"
-rand_chacha = "~0.1.1"
 tempdir = "~0.3.7"
 
 [[bin]]
@@ -47,6 +47,6 @@ name = "safe_vault"
 doc = false
 
 [features]
-mock = ["routing/mock_base", "fxhash", "hex_fmt"]
-mock-parsec = ["routing/mock_parsec", "routing/mock_crypto", "fxhash", "hex_fmt", "phase-one"]
-phase-one = []
+mock_base = ["routing/mock_base", "fxhash", "hex_fmt"]
+mock = ["mock_base"]
+mock_parsec = ["routing/mock_parsec", "routing/mock_crypto", "mock_base"]

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -4,3 +4,4 @@ set -e -x
 
 cargo clippy "$@" --all-targets
 cargo clippy "$@" --all-targets --features=mock --no-default-features
+cargo clippy "$@" --all-targets --features=mock-parsec --no-default-features

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -4,4 +4,4 @@ set -e -x
 
 cargo clippy "$@" --all-targets
 cargo clippy "$@" --all-targets --features=mock --no-default-features
-cargo clippy "$@" --all-targets --features=mock-parsec --no-default-features
+cargo clippy "$@" --all-targets --features=mock_parsec --no-default-features

--- a/scripts/tests
+++ b/scripts/tests
@@ -4,4 +4,4 @@ set -e -x
 
 cargo test "$@" --release
 cargo test "$@" --release --features=mock --no-default-features
-cargo test "$@" --release --features=mock-parsec --no-default-features
+cargo test "$@" --release --features=mock_parsec --no-default-features

--- a/scripts/tests
+++ b/scripts/tests
@@ -4,3 +4,4 @@ set -e -x
 
 cargo test "$@" --release
 cargo test "$@" --release --features=mock --no-default-features
+cargo test "$@" --release --features=mock-parsec --no-default-features

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -185,7 +185,7 @@ impl Config {
         } else if arg == ARGS[11] {
             self.network_config.our_type = unwrap!(value.parse());
         } else {
-            #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
+            #[cfg(not(feature = "mock_base"))]
             {
                 if arg == ARGS[7] {
                     self.network_config.max_msg_size_allowed = Some(unwrap!(value.parse()));
@@ -200,7 +200,7 @@ impl Config {
                 }
             }
 
-            #[cfg(any(feature = "mock", feature = "mock-parsec"))]
+            #[cfg(feature = "mock_base")]
             println!("ERROR");
         }
     }
@@ -278,17 +278,17 @@ fn project_dirs() -> Result<&'static ProjectDirs> {
 #[cfg(test)]
 mod test {
     use super::Config;
-    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
+    #[cfg(not(feature = "mock_base"))]
     use super::ARGS;
     use serde_json;
-    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
+    #[cfg(not(feature = "mock_base"))]
     use std::mem;
     use std::{fs::File, io::Read, path::Path};
-    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
+    #[cfg(not(feature = "mock_base"))]
     use structopt::StructOpt;
     use unwrap::unwrap;
 
-    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
+    #[cfg(not(feature = "mock_base"))]
     #[test]
     fn smoke() {
         let expected_size = if cfg!(target_pointer_width = "64") {

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -185,7 +185,7 @@ impl Config {
         } else if arg == ARGS[11] {
             self.network_config.our_type = unwrap!(value.parse());
         } else {
-            #[cfg(not(feature = "mock"))]
+            #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
             {
                 if arg == ARGS[7] {
                     self.network_config.max_msg_size_allowed = Some(unwrap!(value.parse()));
@@ -200,7 +200,7 @@ impl Config {
                 }
             }
 
-            #[cfg(feature = "mock")]
+            #[cfg(any(feature = "mock", feature = "mock-parsec"))]
             println!("ERROR");
         }
     }
@@ -278,17 +278,17 @@ fn project_dirs() -> Result<&'static ProjectDirs> {
 #[cfg(test)]
 mod test {
     use super::Config;
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
     use super::ARGS;
     use serde_json;
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
     use std::mem;
     use std::{fs::File, io::Read, path::Path};
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
     use structopt::StructOpt;
     use unwrap::unwrap;
 
-    #[cfg(not(feature = "mock"))]
+    #[cfg(not(any(feature = "mock", feature = "mock-parsec")))]
     #[test]
     fn smoke() {
         let expected_size = if cfg!(target_pointer_width = "64") {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,7 +11,7 @@ use crate::{rpc::Rpc, vault::Init, Result};
 use bincode;
 use log::{error, trace};
 use pickledb::{PickleDb, PickleDbDumpPolicy};
-use rand::{distributions::Standard, thread_rng, Rng};
+use rand::{distributions::Standard, CryptoRng, Rng};
 use safe_nd::{
     ClientPublicId, Coins, IDataAddress, PublicId, PublicKey, Request, Result as NdResult, XorName,
 };
@@ -42,8 +42,8 @@ pub(crate) fn new_db<D: AsRef<Path>, N: AsRef<Path>>(
     Ok(result?)
 }
 
-pub(crate) fn random_vec(size: usize) -> Vec<u8> {
-    thread_rng().sample_iter(&Standard).take(size).collect()
+pub(crate) fn random_vec<R: CryptoRng + Rng>(rng: &mut R, size: usize) -> Vec<u8> {
+    rng.sample_iter(&Standard).take(size).collect()
 }
 
 pub(crate) fn serialise<T: Serialize>(data: &T) -> Vec<u8> {

--- a/tests/common/rng.rs
+++ b/tests/common/rng.rs
@@ -6,6 +6,8 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#[cfg(feature = "mock_parsec")]
+use rand::Rng;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use unwrap::unwrap;
@@ -15,4 +17,9 @@ pub type TestRng = ChaChaRng;
 // Create new random number generator suitable for tests, from the given generator from routing.
 pub fn new<R: RngCore>(rng: R) -> TestRng {
     unwrap!(TestRng::from_rng(rng))
+}
+
+#[cfg(feature = "mock_parsec")]
+pub fn new_rng<R: Rng>(rng: &mut R) -> TestRng {
+    TestRng::from_seed(rng.gen())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,8 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-// TODO: make these tests work without mock too.
-#![cfg(any(feature = "mock", feature = "mock-parsec"))]
+#![cfg(feature = "mock_parsec")]
 // For explanation of lint checks, run `rustc -W help`.
 #![forbid(unsafe_code)]
 #![warn(
@@ -65,7 +64,7 @@ fn invalid_signature() {
         signature: None,
     });
     env.poll();
-    match client.expect_response(message_id) {
+    match client.expect_response(message_id, &mut env) {
         Response::GetIData(Err(NdError::InvalidSignature)) => (),
         x => unexpected!(x),
     }
@@ -82,7 +81,7 @@ fn invalid_signature() {
         signature: Some(signature),
     });
     env.poll();
-    match client.expect_response(message_id) {
+    match client.expect_response(message_id, &mut env) {
         Response::GetIData(Err(NdError::InvalidSignature)) => (),
         x => unexpected!(x),
     }
@@ -1991,6 +1990,7 @@ fn get_immutable_data_that_doesnt_exist() {
     // Try to get non-existing unpublished immutable data while having balance
     let start_nano = 1_000_000_000_000;
     common::create_balance(&mut env, &mut client, None, start_nano);
+
     common::send_request_expect_err(
         &mut env,
         &mut client,
@@ -2246,7 +2246,7 @@ fn auth_keys() {
     common::create_balance(&mut env, &mut owner, None, start_nano);
 
     // The app receives the transaction notification too.
-    let _ = app.expect_notification();
+    let _ = app.expect_notification(&mut env);
 
     // Check that listing authorised keys returns an empty collection.
     let mut expected_map = BTreeMap::new();
@@ -2302,7 +2302,6 @@ fn auth_keys() {
 #[test]
 fn app_permissions() {
     let mut env = Environment::new();
-
     let mut owner = env.new_connected_client();
     let balance = unwrap!(Coins::from_nano(1000));
     common::create_balance(&mut env, &mut owner, None, balance);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 // TODO: make these tests work without mock too.
-#![cfg(feature = "mock")]
+#![cfg(any(feature = "mock", feature = "mock-parsec"))]
 // For explanation of lint checks, run `rustc -W help`.
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
This PR contains the work to make vault use real routing (with mock_parsec) during the integration test.
The testing environment contains a network of vaults, and the client requests are handled by the network, instead of just one vault.