### PR TITLE
chore/test: enable tests with feature of mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,7 +498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -509,6 +519,19 @@ dependencies = [
 [[package]]
 name = "err-derive"
 version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "err-derive"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1468,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "quic-p2p"
 version = "0.3.0"
-source = "git+https://github.com/maidsafe/quic-p2p#444204cecbf1fffe39e25e04c1380d3e55ff4fea"
+source = "git+https://github.com/maidsafe/quic-p2p#2ea8c5670cf5969ae68abdbc0d95e9a5184d33cb"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1828,7 +1851,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1879,12 +1902,14 @@ dependencies = [
 [[package]]
 name = "routing"
 version = "0.37.0"
-source = "git+https://github.com/maidsafe/routing.git?branch=fleming#860a666d4cb0b2d4d38520046d6d583520c12ddc"
+source = "git+https://github.com/maidsafe/routing.git?branch=fleming#dddac2fbb5dc7ed703a95ab9af9748f6ff1b4863"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake_clock 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1897,7 +1922,6 @@ dependencies = [
  "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "parsec 0.5.0 (git+https://github.com/maidsafe/parsec?rev=818676c)",
  "quic-p2p 0.3.0 (git+https://github.com/maidsafe/quic-p2p)",
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource_proof 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2213,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2661,7 +2685,7 @@ name = "unicode-normalization"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2963,6 +2987,7 @@ dependencies = [
 "checksum ct-logs 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b4660f8b07a560a88c02d76286edb9f0d5d64e495d2b0f233186155aa51be1f"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
+"checksum derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72d337a64190607d4fcca2cb78982c5dd57f4916e19696b48a575fa746b6cb0f"
 "checksum directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
@@ -2970,9 +2995,10 @@ dependencies = [
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum ed25519-dalek 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d07e8b8a8386c3b89a7a4b329fdfa4cb545de2545e9e2ebbc3dd3929253e426"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-"checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
+"checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum err-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b41487fadaa500d02a819eefcde5f713599a01dd51626ef25d2d72d87115667b"
+"checksum err-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ead97ef6ef5530312e584d24b1ef31e96455bc2135945109fc737fe8b62ff4a5"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
@@ -3150,7 +3176,7 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-"checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+"checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -965,7 +965,7 @@ impl ClientHandler {
             .unwrap_or(false);
         if own_request {
             return Some(Action::ConsensusVote(ConsensusAction::Forward {
-                request: request.clone(),
+                request,
                 client_public_id: requester.clone(),
                 message_id,
             }));

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -178,7 +178,7 @@ impl Environment {
         let conn_infos: Vec<_> = self
             .vaults
             .iter_mut()
-            .map(|vault| vault.connection_info().clone())
+            .map(|vault| vault.connection_info())
             .collect();
         for conn_info in conn_infos {
             client.quic_p2p().connect_to(conn_info.clone());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-#![cfg(feature = "mock_parsec")]
+#![cfg(feature = "mock_base")]
 // For explanation of lint checks, run `rustc -W help`.
 #![forbid(unsafe_code)]
 #![warn(
@@ -223,7 +223,7 @@ fn create_login_packet_for_other() {
             new_owner: *new_client.public_id().public_key(),
             amount: unwrap!(Coins::from_nano(nano_to_transfer)),
             transaction_id: 2,
-            new_login_packet: login_packet.clone(),
+            new_login_packet: login_packet,
         },
         NdError::BalanceExists,
     );
@@ -982,7 +982,7 @@ fn append_only_data_get_entries() {
     common::send_request_expect_err(
         &mut env,
         &mut client,
-        Request::PutAData(data.clone()),
+        Request::PutAData(data),
         NdError::InsufficientBalance,
     );
 
@@ -1605,7 +1605,7 @@ fn append_only_data_put_owners() {
         owners_index: 1,
     };
 
-    unwrap!(data.append_permissions(perms_0.clone(), 0));
+    unwrap!(data.append_permissions(perms_0, 0));
     unwrap!(data.append(
         vec![ADataEntry {
             key: b"one".to_vec(),
@@ -1731,7 +1731,7 @@ fn append_only_data_append_seq() {
         owners_index: 1,
     };
 
-    unwrap!(data.append_permissions(perms_0.clone(), 0));
+    unwrap!(data.append_permissions(perms_0, 0));
     unwrap!(data.append(
         vec![ADataEntry {
             key: b"one".to_vec(),
@@ -1813,7 +1813,7 @@ fn append_only_data_append_unseq() {
         owners_index: 1,
     };
 
-    unwrap!(data.append_permissions(perms_0.clone(), 0));
+    unwrap!(data.append_permissions(perms_0, 0));
     unwrap!(data.append(vec![ADataEntry {
         key: b"one".to_vec(),
         value: b"foo".to_vec()
@@ -1948,15 +1948,11 @@ fn put_immutable_data() {
     );
 
     // Published data can be put again, but unpublished not
-    common::perform_mutation(
-        &mut env,
-        &mut client_a,
-        Request::PutIData(pub_idata.clone()),
-    );
+    common::perform_mutation(&mut env, &mut client_a, Request::PutIData(pub_idata));
     common::send_request_expect_err(
         &mut env,
         &mut client_b,
-        Request::PutIData(unpub_idata.clone()),
+        Request::PutIData(unpub_idata),
         NdError::DataExists,
     );
 
@@ -2144,7 +2140,7 @@ fn delete_immutable_data() {
     common::create_balance(&mut env, &mut client_a, None, start_nano);
 
     let raw_data = vec![1, 2, 3];
-    let pub_idata = IData::Pub(PubImmutableData::new(raw_data.clone()));
+    let pub_idata = IData::Pub(PubImmutableData::new(raw_data));
     let pub_idata_address: XorName = *pub_idata.address().name();
     common::perform_mutation(&mut env, &mut client_a, Request::PutIData(pub_idata));
 
@@ -2166,7 +2162,7 @@ fn delete_immutable_data() {
 
     let raw_data = vec![42];
     let owner = client_a.public_id().public_key();
-    let unpub_idata = IData::Unpub(UnpubImmutableData::new(raw_data.clone(), *owner));
+    let unpub_idata = IData::Unpub(UnpubImmutableData::new(raw_data, *owner));
     let unpub_idata_address: XorName = *unpub_idata.address().name();
     common::perform_mutation(&mut env, &mut client_a, Request::PutIData(unpub_idata));
 
@@ -2599,11 +2595,7 @@ fn read_seq_mutable_data() {
         Default::default(),
         *client.public_id().public_key(),
     );
-    common::perform_mutation(
-        &mut env,
-        &mut client,
-        Request::PutMData(MData::Seq(mdata.clone())),
-    );
+    common::perform_mutation(&mut env, &mut client, Request::PutMData(MData::Seq(mdata)));
 
     // Get version.
     let address = MDataAddress::Seq { name, tag };
@@ -2658,11 +2650,7 @@ fn mutate_seq_mutable_data() {
     let name: XorName = env.rng().gen();
     let tag = 100;
     let mdata = SeqMutableData::new(name, tag, *client.public_id().public_key());
-    common::perform_mutation(
-        &mut env,
-        &mut client,
-        Request::PutMData(MData::Seq(mdata.clone())),
-    );
+    common::perform_mutation(&mut env, &mut client, Request::PutMData(MData::Seq(mdata)));
 
     // Get a non-existant value by key.
     let address = MDataAddress::Seq { name, tag };
@@ -2770,7 +2758,7 @@ fn mutate_unseq_mutable_data() {
     common::perform_mutation(
         &mut env,
         &mut client,
-        Request::PutMData(MData::Unseq(mdata.clone())),
+        Request::PutMData(MData::Unseq(mdata)),
     );
 
     // Get a non-existant value by key.
@@ -2864,7 +2852,7 @@ fn mutable_data_permissions() {
     common::perform_mutation(
         &mut env,
         &mut client_a,
-        Request::PutMData(MData::Unseq(mdata.clone())),
+        Request::PutMData(MData::Unseq(mdata)),
     );
 
     // Make sure client B can't insert anything.
@@ -2943,7 +2931,7 @@ fn delete_mutable_data() {
     common::perform_mutation(
         &mut env,
         &mut client_a,
-        Request::PutMData(MData::Unseq(mdata.clone())),
+        Request::PutMData(MData::Unseq(mdata)),
     );
     let balance_a = unwrap!(balance_a.checked_sub(*COST_OF_PUT));
     common::send_request_expect_ok(&mut env, &mut client_a, Request::GetBalance, balance_a);


### PR DESCRIPTION
This PR contains the work of re-enabling integration tests when using `mock` feature.
Also resolved some clippy error due to update.