### PR TITLE
fix/vault: upgrade routing and avoid calling node poll test function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "routing"
 version = "0.37.0"
-source = "git+https://github.com/maidsafe/routing.git?branch=fleming#134c0e8f7aa3058120f795c2ca5d53f0ffd0a612"
+source = "git+https://github.com/maidsafe/routing.git?branch=fleming#05c01c46a55ee5601293e80c21b100d6aae911bc"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "config_file_handler 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -21,8 +21,6 @@ use crossbeam_channel::{Receiver, Select};
 use log::{error, info, trace, warn};
 use rand::{CryptoRng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
-#[cfg(feature = "mock_parsec")]
-use routing::EventStream;
 use safe_nd::{NodeFullId, Request, XorName};
 use std::borrow::Cow;
 use std::{
@@ -211,11 +209,6 @@ impl<R: CryptoRng + Rng> Vault<R> {
     pub fn poll(&mut self) -> bool {
         let mut _processed = false;
         loop {
-            #[cfg(feature = "mock_parsec")]
-            {
-                _processed = self.routing_node.borrow_mut().poll();
-            }
-
             let mut sel = Select::new();
             let mut r_node = self.routing_node.borrow_mut();
             r_node.register(&mut sel);


### PR DESCRIPTION
cargo update -p routing

There was an issue where timeouts were not processed with the normal
register/ready/try_ready/handle_selected_operation. This is fixed with
latest routing code.

Test:
test + clippy