### PR TITLE
fix/client_handler: remove refund for login packet exists errors

### DIFF
--- a/src/client_handler.rs
+++ b/src/client_handler.rs
@@ -1491,14 +1491,15 @@ impl ClientHandler {
                     })
                     .map_err(|error| error.to_string().into())
             };
-            let refund = utils::get_refund_for_put(&result);
             Some(Action::RespondToClientHandlers {
                 sender: *login_packet.destination(),
                 rpc: Rpc::Response {
                     response: Response::Transaction(result),
                     requester: payer,
                     message_id,
-                    refund,
+                    // A new balance is already created as
+                    // a part of the flow. So no refund is processed.
+                    refund: None,
                 },
             })
         }


### PR DESCRIPTION
- The cost of `CreateLoginPacketFor` is only 1 PUT. In cases where the
request creates the new balance successfully, but, fails at the stage
where the login packet is inserted, the client should not be refunded. A
refund in this situation would allow clients to create unlimited number
of balances without spending any coins. This could lead to a potential
spam attack.