### PR TITLE
pull routing and quic_p2p with separate client channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "mock-quic-p2p"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/quic-p2p?rev=f1991746a8#f1991746a82ef21ac69b26e17ba8c6a6b4c15653"
+source = "git+https://github.com/maidsafe/quic-p2p?rev=b50a029#b50a029600f36b0f98f0c665ccc71e200de41168"
 dependencies = [
  "bytes 0.4.12",
  "crossbeam-channel",
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "quic-p2p"
 version = "0.3.0"
-source = "git+https://github.com/maidsafe/quic-p2p?rev=f1991746a8#f1991746a82ef21ac69b26e17ba8c6a6b4c15653"
+source = "git+https://github.com/maidsafe/quic-p2p?rev=b50a029#b50a029600f36b0f98f0c665ccc71e200de41168"
 dependencies = [
  "base64 0.10.1",
  "bincode 1.1.4",
@@ -2281,7 +2281,7 @@ dependencies = [
 [[package]]
 name = "routing"
 version = "0.37.0"
-source = "git+https://github.com/maidsafe/routing.git?branch=fleming#9a28bcb208c1347acd91b7b0bd6545a5875f6ae2"
+source = "git+https://github.com/maidsafe/routing.git?branch=fleming#13b1ffecfbf61407c18ed8b65ed76b6c576962a4"
 dependencies = [
  "bincode 1.1.4",
  "bytes 0.4.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hex = "~0.3.2"
 hex_fmt = { version = "~0.3.0", optional = true }
 lazy_static = "~1"
 log = "~0.4.7"
-mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "f1991746a8", optional = true }
+mock-quic-p2p = { git = "https://github.com/maidsafe/quic-p2p", rev = "b50a029", optional = true }
 pickledb = "~0.4.0"
 quick-error = "~1.2.2"
 rand = "~0.6.5"

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -115,7 +115,7 @@ mod detail {
             log::error!("Failed to set interrupt handler: {:?}", error)
         }
 
-        let (routing_node, routing_rx) = Node::builder()
+        let (routing_node, routing_rx, client_rx) = Node::builder()
             .first(config.is_first())
             .network_config(config.network_config().clone())
             .create();
@@ -124,7 +124,14 @@ mod detail {
 
         let mut rng = rand::thread_rng();
 
-        match Vault::new(routing_node, routing_rx, &config, command_rx, &mut rng) {
+        match Vault::new(
+            routing_node,
+            routing_rx,
+            client_rx,
+            &config,
+            command_rx,
+            &mut rng,
+        ) {
             Ok(mut vault) => {
                 let our_conn_info = unwrap!(vault.our_connection_info());
                 println!(

--- a/src/mock_routing/mod.rs
+++ b/src/mock_routing/mod.rs
@@ -6,13 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-pub use routing::{event, NetworkConfig, P2pNode, RoutingError};
+pub use routing::{event, NetworkConfig, NetworkEvent, P2pNode, RoutingError};
 
 use bytes::Bytes;
 use crossbeam_channel::{self as mpmc, Receiver, RecvError, Select, Sender};
 use log::trace;
-use mock_quic_p2p::{self as quic_p2p, Event as NetworkEvent, Peer, QuicP2p, QuicP2pError};
-use routing::event::Client as ClientEvent;
+use mock_quic_p2p::{self as quic_p2p, Peer, QuicP2p, QuicP2pError};
 use routing::{event::Event, XorName};
 use std::{
     cell::RefCell,
@@ -58,8 +57,8 @@ impl ConsensusGroup {
 pub struct Node {
     events_tx: Sender<Event>,
     quic_p2p: QuicP2p,
-    network_rx: Receiver<NetworkEvent>,
-    network_rx_idx: usize,
+    network_node_rx: Receiver<NetworkEvent>,
+    network_node_rx_idx: usize,
     consensus_group: Option<Weak<RefCell<ConsensusGroup>>>,
 }
 
@@ -74,7 +73,7 @@ impl Node {
     /// Registering of interests with the event loop will happen here. Without this routing will
     /// not be able to take part in the event loop triggers.
     pub fn register<'a>(&'a mut self, sel: &mut Select<'a>) {
-        self.network_rx_idx = sel.recv(&self.network_rx);
+        self.network_node_rx_idx = sel.recv(&self.network_node_rx);
     }
 
     /// Returns the connection information of all the current section elders.
@@ -96,9 +95,8 @@ impl Node {
     /// Handle an event loop trigger with the mentioned operation
     pub fn handle_selected_operation(&mut self, op_index: usize) -> Result<(), RecvError> {
         match op_index {
-            idx if idx == self.network_rx_idx => {
-                let event = self.network_rx.recv()?;
-                self.handle_network_event(event);
+            idx if idx == self.network_node_rx_idx => {
+                let _event = self.network_node_rx.recv()?;
             }
             idx => panic!("Unknown operation selected: {}", idx),
         }
@@ -146,46 +144,6 @@ impl Node {
         self.quic_p2p.disconnect_from(peer_addr);
         Ok(())
     }
-
-    fn handle_network_event(&mut self, event: NetworkEvent) {
-        if let Ok(client_event) = into_client_event(event) {
-            unwrap!(self.events_tx.send(Event::Client(client_event)));
-        }
-    }
-}
-
-/// Map a Network event into a ClientEvent if applies.
-pub fn into_client_event(network_event: NetworkEvent) -> Result<ClientEvent, ()> {
-    use NetworkEvent::*;
-
-    let client_event = match network_event {
-        ConnectedTo { peer } => ClientEvent::Connected {
-            peer_addr: peer.peer_addr(),
-        },
-        NewMessage { peer, msg } => ClientEvent::NewMessage {
-            peer_addr: peer.peer_addr(),
-            msg,
-        },
-        ConnectionFailure { peer, err: _err } => ClientEvent::ConnectionFailure {
-            peer_addr: peer.peer_addr(),
-        },
-        UnsentUserMessage { peer, msg, token } => ClientEvent::UnsentUserMsg {
-            peer_addr: peer.peer_addr(),
-            msg,
-            token,
-        },
-        SentUserMessage { peer, msg, token } => ClientEvent::SentUserMsg {
-            peer_addr: peer.peer_addr(),
-            msg,
-            token,
-        },
-        _event => {
-            // There's no equivalent `ClientEvent`
-            return Err(());
-        }
-    };
-
-    Ok(client_event)
 }
 
 /// A builder to configure and create a new `Node`.
@@ -193,19 +151,21 @@ pub struct NodeBuilder {}
 
 impl NodeBuilder {
     /// Creates new `Node`.
-    pub fn create(self) -> (Node, Receiver<Event>) {
-        let (quic_p2p, network_rx) = unwrap!(setup_quic_p2p(&Default::default()));
+    pub fn create(self) -> (Node, Receiver<Event>, Receiver<NetworkEvent>) {
+        let (quic_p2p, network_node_rx, network_client_rx) =
+            unwrap!(setup_quic_p2p(&Default::default()));
         let (events_tx, events_rx) = mpmc::unbounded();
 
         (
             Node {
-                network_rx,
+                network_node_rx,
                 quic_p2p,
                 events_tx,
-                network_rx_idx: 0,
+                network_node_rx_idx: 0,
                 consensus_group: None,
             },
             events_rx,
+            network_client_rx,
         )
     }
 
@@ -213,8 +173,9 @@ impl NodeBuilder {
     pub fn create_within_group(
         self,
         consensus_group: ConsensusGroupRef,
-    ) -> (Node, Receiver<Event>) {
-        let (quic_p2p, network_rx) = unwrap!(setup_quic_p2p(&Default::default()));
+    ) -> (Node, Receiver<Event>, Receiver<NetworkEvent>) {
+        let (quic_p2p, network_node_rx, network_client_rx) =
+            unwrap!(setup_quic_p2p(&Default::default()));
         let (events_tx, events_rx) = mpmc::unbounded();
 
         consensus_group
@@ -224,23 +185,32 @@ impl NodeBuilder {
 
         (
             Node {
-                network_rx,
+                network_node_rx,
                 quic_p2p,
                 events_tx,
-                network_rx_idx: 0,
+                network_node_rx_idx: 0,
                 consensus_group: Some(Rc::downgrade(&consensus_group)),
             },
             events_rx,
+            network_client_rx,
         )
     }
 }
 
 fn setup_quic_p2p(
     config: &NetworkConfig,
-) -> Result<(QuicP2p, Receiver<NetworkEvent>), QuicP2pError> {
-    let (event_sender, event_receiver) = crossbeam_channel::unbounded();
-    let quic_p2p = quic_p2p::Builder::new(event_sender)
+) -> Result<(QuicP2p, Receiver<NetworkEvent>, Receiver<NetworkEvent>), QuicP2pError> {
+    let (event_senders, node_receiver, client_receiver) = {
+        let (node_tx, node_rx) = crossbeam_channel::unbounded();
+        let (client_tx, client_rx) = crossbeam_channel::unbounded();
+        (
+            quic_p2p::EventSenders { node_tx, client_tx },
+            node_rx,
+            client_rx,
+        )
+    };
+    let quic_p2p = quic_p2p::Builder::new(event_senders)
         .with_config(config.clone())
         .build()?;
-    Ok((quic_p2p, event_receiver))
+    Ok((quic_p2p, node_receiver, client_receiver))
 }


### PR DESCRIPTION
Depends on https://github.com/maidsafe/quic-p2p/pull/95 and https://github.com/maidsafe/routing/pull/2052

We can now access directly the client messages and do not need to
rely on Routing to provide us with these. We select from the new
channel that routing returns and handle client event direclty.
