### PR TITLE
fix/ci: on push run ci on master branch and upload & push coverage

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,16 +1,17 @@
-# Fleming workflow
+# Master workflow
 #
-# Runs when a PR has been merged to the fleming branch.
+# Runs when a PR has been merged to the master branch.
 #
 # 1. Generates a release build.
 # 2. If the last commit is a version change, publish.
+# 3. Gather coverage stats and push to coveralls.io
 
-name: Fleming
+name: Master
 
 on:
   push:
     branches:
-      - fleming
+      - master
 
 env:
   # Run all cargo commands with --verbose.
@@ -18,16 +19,13 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
-    name: Build
+  build_win_mac:
+    name: Build_win_mac
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [windows-latest, macOS-latest]
         include:
-          - os: ubuntu-latest
-            build-script: make musl
-            target: x86_64-unknown-linux-musl
           - os: windows-latest
             build-script: make build
             target: x86_64-pc-windows-gnu
@@ -68,13 +66,74 @@ jobs:
           name: safe_vault-${{ matrix.target }}-prod
           path: artifacts
 
+  build_linux:
+    name: Build_Linux
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            build-script: make musl
+            target: x86_64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      # Run build.
+      - shell: bash
+        run: ${{ matrix.build-script }}
+      # Upload artifacts.
+      - uses: actions/upload-artifact@master
+        with:
+          name: safe_vault-${{ matrix.target }}-prod
+          path: artifacts
+
+      # Run cargo tarpaulin & push result to coveralls.io
+      - name: rust-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1.0
+        with:
+          args: '--features=mock --out Lcov -- --test-threads 1'
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v1.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          path-to-lcov: ./lcov.info
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+
   # Unfortunately, for artifact retrieval, there's not really a way to avoid having this huge list of
   # 'download-artifact' actions. We could perhaps implement our own 'retrieve all build artifacts'
   # action.
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build_win_mac, build_linux]
     env:
       AWS_ACCESS_KEY_ID: AKIAVVODCRMSJ5MV63VB
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Fleming branch has been merged to master now, but CI still points
to fleming. Update to point to master.
Also added running cargo tarpaulin on pushes to master, then upload
results to coveralls.io

Tested cargo tarpaulin & coveralls part on my fork and both the PR & push to master worked fine - issue why it didn't work previously (before it was stripped out from push) was because it only works on ubuntu, so had to separate the ubuntu build step out on it's own and add the cargo tarpaulin & coveralls steps to that. Then had to make the deploy stage wait until all build steps have finished.