### PR TITLE
Reading config file returns option

### DIFF
--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -44,7 +44,7 @@ mod detail {
 
     /// Runs a SAFE Network vault.
     pub fn main() {
-        let mut config = Config::new();
+        let mut config = Config::new().expect("Error reading configuration file");
 
         if let Some(c) = &config.completions() {
             match c.parse::<clap::Shell>() {


### PR DESCRIPTION
Originally from #899 

disambiguate following cases:
- config file found and deserialized successfully
- config file found but error occurred (panic)
- no config file found (use default config)

update calls to trace with println as logging not available at this point
(logging setup requires config)

Resolves #898

Authored by @m-cat  and @peter-wilkins